### PR TITLE
Updating actors echo, kvcounter and kvcounter-as to interfaces and wasmcloud contract

### DIFF
--- a/echo/Cargo.lock
+++ b/echo/Cargo.lock
@@ -3,6 +3,7 @@
 [[package]]
 name = "actor-core"
 version = "0.2.0"
+source = "git+https://github.com/wasmcloud/actor-interfaces?branch=main#1d029dfba75488792ffe23952368250542e07b01"
 dependencies = [
  "lazy_static",
  "log",
@@ -16,6 +17,7 @@ dependencies = [
 [[package]]
 name = "actor-http-server"
 version = "0.1.0"
+source = "git+https://github.com/wasmcloud/actor-interfaces?branch=main#1d029dfba75488792ffe23952368250542e07b01"
 dependencies = [
  "lazy_static",
  "log",

--- a/echo/Cargo.lock
+++ b/echo/Cargo.lock
@@ -2,15 +2,13 @@
 # It is not intended for manual editing.
 [[package]]
 name = "actor-core"
-version = "0.1.0"
-source = "git+https://github.com/wascc/actor-interfaces?branch=main#efa5db165718523cc7c3207edfbca007eaa11fee"
+version = "0.2.0"
 dependencies = [
  "lazy_static",
  "log",
  "rmp-serde",
  "serde",
  "serde_bytes",
- "serde_derive",
  "serde_json",
  "wapc-guest",
 ]
@@ -18,7 +16,6 @@ dependencies = [
 [[package]]
 name = "actor-http-server"
 version = "0.1.0"
-source = "git+https://github.com/wascc/actor-interfaces?branch=main#efa5db165718523cc7c3207edfbca007eaa11fee"
 dependencies = [
  "lazy_static",
  "log",
@@ -32,15 +29,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
 name = "cfg-if"
@@ -50,7 +47,7 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "echo"
-version = "0.0.2"
+version = "0.1.0"
 dependencies = [
  "actor-core",
  "actor-http-server",
@@ -61,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "lazy_static"
@@ -73,9 +70,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
 dependencies = [
  "cfg-if",
  "serde",
@@ -83,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.11"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
 ]
@@ -101,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.3"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
+checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
 dependencies = [
  "proc-macro2",
 ]
@@ -120,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "rmp-serde"
-version = "0.14.4"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce7d70c926fe472aed493b902010bccc17fa9f7284145cb8772fd22fdb052d8"
+checksum = "046c5bb3a3728ed6a97d7337e436ec5966fa5e71899c5312c3aa0fda7f949c7f"
 dependencies = [
  "byteorder",
  "rmp",
@@ -131,15 +128,15 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "serde"
-version = "1.0.118"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
+checksum = "166b2349061381baf54a58e4b13c89369feb0ef2eaa57198899e2312aac30aab"
 dependencies = [
  "serde_derive",
 ]
@@ -155,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.118"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
+checksum = "0ca2a8cb5805ce9e3b95435e3765b7b553cecc762d938d409434338386cb5775"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -166,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
+checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
 dependencies = [
  "itoa",
  "ryu",
@@ -177,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.54"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2af957a63d6bd42255c359c93d9bfdb97076bd3b820897ce55ffbfbf107f44"
+checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -188,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "wapc-guest"

--- a/echo/Cargo.toml
+++ b/echo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "echo"
-version = "0.0.2"
-authors = ["Kevin Hoffman <alothien@gmail.com>"]
+version = "0.1.0"
+authors = ["wasmCloud Team"]
 edition = "2018"
 
 [lib]
@@ -9,8 +9,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wapc-guest = "0.4.0"
-actor-core = { git = "https://github.com/wascc/actor-interfaces", branch = "main" }
-actor-http-server = { git = "https://github.com/wascc/actor-interfaces", branch = "main"}
+actor-core = { path = "../../actor-interfaces/rust/actor-core", features = ["guest"] }
+actor-http-server = { path = "../../actor-interfaces/rust/http-server", features = ["guest"]}
 serde_json ="1.0.60"
 serde = {version = "1.0.118", features = ["derive"]}
 

--- a/echo/Cargo.toml
+++ b/echo/Cargo.toml
@@ -9,8 +9,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wapc-guest = "0.4.0"
-actor-core = { path = "../../actor-interfaces/rust/actor-core", features = ["guest"] }
-actor-http-server = { path = "../../actor-interfaces/rust/http-server", features = ["guest"]}
+actor-core = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main", features = ["guest"] }
+actor-http-server = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main", features = ["guest"]}
 serde_json ="1.0.60"
 serde = {version = "1.0.118", features = ["derive"]}
 

--- a/echo/README.md
+++ b/echo/README.md
@@ -1,11 +1,5 @@
 # Echo Example
 
-This example is designed to illustrate a few simple aspects of coding an actor module with waSCC. The first shows how to respond to simple HTTP requests, but this sample also shows how to use `serde` for JSON serialization.
+This example is designed to illustrate a few simple aspects of coding an actor module with wasmCloud. The first shows how to respond to simple HTTP requests, but this sample also shows how to use `serde` for JSON serialization.
 
 This actor module responds to all incoming HTTP requests by returning a JSON object describing the inbound request.
-
-You can build this example with a simple `cargo build`. In order to run it within a host runtime, you will need to sign it with the [wascap](https://github.com/wascc/wascap) tool (which uses the [nkeys](https://github.com/encabulators/nkeys) command-line tool to generate keys). You can also copy sample keys from the [starter template](https://github.com/wascc/new-actor-template).
-
-To see this sample run inside of a waSCC host, take a look at the **examples** directory in the [wascc-host](https://github.com/wascc/wascc-host) repository.
-
-There is also a [tutorial](https://wascc-dev.netlify.com/tutorials/first-actor/) that covers creating this sample and running it in a host runtime.

--- a/kvcounter-as/assembly/index.ts
+++ b/kvcounter-as/assembly/index.ts
@@ -1,6 +1,6 @@
 import { Request, Response, ResponseBuilder, Handlers as HTTPHandlers } from "../../../actor-interfaces/assemblyscript/http-server/assembly/module";
 import { Host as KV } from "../../../actor-interfaces/assemblyscript/keyvalue/assembly/module";
-import { HealthCheckResponse, HealthCheckRequest, Handlers as CoreHandlers } from "../../../actor-interfaces/assemblyscript/actor-core/assembly/module";
+import { HealthCheckResponse, HealthCheckRequest, Handlers as CoreHandlers, HealthCheckResponseBuilder } from "../../../actor-interfaces/assemblyscript/actor-core/assembly/module";
 import { JSONEncoder } from "assemblyscript-json";
 
 export function wapc_init(): void {
@@ -9,11 +9,11 @@ export function wapc_init(): void {
 }
 
 function HealthCheck(request: HealthCheckRequest): HealthCheckResponse {
-  return new HealthCheckResponse();
+  return new HealthCheckResponseBuilder().withHealthy(true).withMessage("AssemblyScript KVCounter Healthy").build();
 }
 
 function HandleRequest(request: Request): Response {
-  const kv = new KV("");
+  const kv = new KV("default");
   const key = request.path.replace("/", ":");
   const result = kv.Add(key, 1);
 

--- a/kvcounter-as/assembly/index.ts
+++ b/kvcounter-as/assembly/index.ts
@@ -1,18 +1,27 @@
-import { handleCall, consoleLog, handleAbort } from "wapc-guest-as";
-import { Request, Response, ResponseBuilder, Handlers } from "wascc-actor-as/httpserver";
-import { Host as KV } from "wascc-actor-as/kv";
+import { Request, Response, ResponseBuilder, Handlers as HTTPHandlers } from "../../../actor-interfaces/assemblyscript/http-server/assembly/module";
+import { Host as KV } from "../../../actor-interfaces/assemblyscript/keyvalue/assembly/module";
+import { HealthCheckResponse, HealthCheckRequest, Handlers as CoreHandlers } from "../../../actor-interfaces/assemblyscript/actor-core/assembly/module";
 import { JSONEncoder } from "assemblyscript-json";
 
-function handleRequest(request: Request): Response {
+export function wapc_init(): void {
+  CoreHandlers.registerHealthRequest(HealthCheck);
+  HTTPHandlers.registerHandleRequest(HandleRequest);
+}
+
+function HealthCheck(request: HealthCheckRequest): HealthCheckResponse {
+  return new HealthCheckResponse();
+}
+
+function HandleRequest(request: Request): Response {
   const kv = new KV("");
-  const key = request.path.replaceAll("/", ":");      
-  const result = kv.atomicAdd(key, 1);  
-     
+  const key = request.path.replace("/", ":");
+  const result = kv.Add(key, 1);
+
   let encoder = new JSONEncoder();
 
   // Construct output JSON
   encoder.pushObject("");
-  encoder.setInteger("count", result.value);  
+  encoder.setInteger("count", result.value);
   encoder.popObject();
 
   // Get serialized data
@@ -25,23 +34,19 @@ function handleRequest(request: Request): Response {
     .build();
 }
 
-
-// Ceremony required for module entry points
-
-export function _start(): void {
-  Handlers.handleRequest(handleRequest);
-}
+// Boilerplate code for waPC.  Do not remove.
+import { handleCall, handleAbort } from "@wapc/as-guest";
 
 export function __guest_call(operation_size: usize, payload_size: usize): bool {
   return handleCall(operation_size, payload_size);
 }
 
-// Abort function - this should probably be in the actor SDK and not in an actor...
-export function abort(
-    message: string | null,
-    fileName: string | null,
-    lineNumber: u32,
-    columnNumber: u32
-  ): void {
-    handleAbort(message, fileName, lineNumber, columnNumber);
-  }
+// Abort function
+function abort(
+  message: string | null,
+  fileName: string | null,
+  lineNumber: u32,
+  columnNumber: u32
+): void {
+  handleAbort(message, fileName, lineNumber, columnNumber);
+}

--- a/kvcounter-as/assembly/index.ts
+++ b/kvcounter-as/assembly/index.ts
@@ -1,6 +1,6 @@
-import { Request, Response, ResponseBuilder, Handlers as HTTPHandlers } from "../../../actor-interfaces/assemblyscript/http-server/assembly/module";
-import { Host as KV } from "../../../actor-interfaces/assemblyscript/keyvalue/assembly/module";
-import { HealthCheckResponse, HealthCheckRequest, Handlers as CoreHandlers, HealthCheckResponseBuilder } from "../../../actor-interfaces/assemblyscript/actor-core/assembly/module";
+import { Request, Response, ResponseBuilder, Handlers as HTTPHandlers } from "@wasmcloud/actor-http-server";
+import { Host as KV } from "@wasmcloud/actor-keyvalue";
+import { HealthCheckResponse, HealthCheckRequest, Handlers as CoreHandlers, HealthCheckResponseBuilder } from "@wasmcloud/actor-core";
 import { JSONEncoder } from "assemblyscript-json";
 
 export function wapc_init(): void {

--- a/kvcounter-as/package-lock.json
+++ b/kvcounter-as/package-lock.json
@@ -1,9 +1,19 @@
 {
     "name": "kvcounter-as",
-    "version": "0.0.1",
+    "version": "0.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@wapc/as-guest": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@wapc/as-guest/-/as-guest-0.2.1.tgz",
+            "integrity": "sha512-67qrVC5MflfdTuXCG4P5mysifGgIt+AshBX5ZC1uRWYsBpsxQzP1WP9w/4vWJtTyTXUomvL9unmKJq+dLwqfNw=="
+        },
+        "@wapc/as-msgpack": {
+            "version": "0.1.11",
+            "resolved": "https://registry.npmjs.org/@wapc/as-msgpack/-/as-msgpack-0.1.11.tgz",
+            "integrity": "sha512-DhzSHU7Wp7Ndl8qjPO2NN7grBH7uCiGwT60EtoCDlfLMdjFfZwGsjvaHmvTtv285vyH/P9Pyhst5id0bJ0ePOg=="
+        },
         "ansi-regex": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -28,17 +38,13 @@
                 "sprintf-js": "~1.0.2"
             }
         },
-        "as-msgpack": {
-            "version": "git+https://github.com/wapc/as-msgpack.git#51c272f86ef10c3248ecebcc6a9045cdb05dfa52",
-            "from": "git+https://github.com/wapc/as-msgpack.git#v0.1.6"
-        },
         "assemblyscript": {
-            "version": "0.9.4",
-            "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.9.4.tgz",
-            "integrity": "sha512-GabjIxYt5uI3nyZNYzw6VtHyZcjVtcw8tbtEbXGvbrp3+A5p3zQ2yrU03tSiRR+WTeGx2aS8c6T+y2gGfjyvqw==",
+            "version": "0.17.14",
+            "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.17.14.tgz",
+            "integrity": "sha512-TLuwNvZAIH26wu2puKpAJokzLp10kJkVXxbgDjFFmbW9VF/qg7rkmi0hjsiu41bjoH1UaVgY4vYvbbUeOHtKyg==",
             "dev": true,
             "requires": {
-                "binaryen": "91.0.0-nightly.20200310",
+                "binaryen": "98.0.0-nightly.20201109",
                 "long": "^4.0.0"
             }
         },
@@ -53,9 +59,9 @@
             "dev": true
         },
         "binaryen": {
-            "version": "91.0.0-nightly.20200310",
-            "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-91.0.0-nightly.20200310.tgz",
-            "integrity": "sha512-MmDzq267aa61HdEQeYiz+7guJlsYk2/6NxWC8I4w1jijqDwoqyZZxi7UYnTH7QvfLrNdMjweEgfT7FHjkvkPmQ==",
+            "version": "98.0.0-nightly.20201109",
+            "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-98.0.0-nightly.20201109.tgz",
+            "integrity": "sha512-iRarAqdH5lMWlMBzrDuJgLYJR2g4QXk93iYE2zpr6gEZkb/jCgDpPUXdhuN11Ge1zZ/6By4DwA1mmifcx7FWaw==",
             "dev": true
         },
         "brace-expansion": {
@@ -371,18 +377,6 @@
             "dev": true,
             "requires": {
                 "has-flag": "^3.0.0"
-            }
-        },
-        "wapc-guest-as": {
-            "version": "git+https://github.com/wapc/wapc-guest-as.git#f92d61114b3df0a8c19e6f8151b652817dd8b2a4",
-            "from": "git+https://github.com/wapc/wapc-guest-as.git#v0.2.0"
-        },
-        "wascc-actor-as": {
-            "version": "git+https://github.com/wascc/wascc-actor-as.git#6abce798c82edcb536879211d3f87c639fb9df51",
-            "from": "git+https://github.com/wascc/wascc-actor-as.git",
-            "requires": {
-                "as-msgpack": "git+https://github.com/wapc/as-msgpack.git#v0.1.6",
-                "wapc-guest-as": "git+https://github.com/wapc/wapc-guest-as.git#v0.2.0"
             }
         },
         "wcwidth": {

--- a/kvcounter-as/package-lock.json
+++ b/kvcounter-as/package-lock.json
@@ -14,6 +14,33 @@
             "resolved": "https://registry.npmjs.org/@wapc/as-msgpack/-/as-msgpack-0.1.11.tgz",
             "integrity": "sha512-DhzSHU7Wp7Ndl8qjPO2NN7grBH7uCiGwT60EtoCDlfLMdjFfZwGsjvaHmvTtv285vyH/P9Pyhst5id0bJ0ePOg=="
         },
+        "@wasmcloud/actor-core": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@wasmcloud/actor-core/-/actor-core-0.1.1.tgz",
+            "integrity": "sha512-B45w3PuVwdDDewKKXzk9Q4ls/P3OyRcwtbxJC91Okkwglj2AEdXUcizMYup/9pBJKx5tLvrZQTyM5Gq8UkS3cw==",
+            "requires": {
+                "@wapc/as-guest": "^v0.2.1",
+                "@wapc/as-msgpack": "^0.1.11"
+            }
+        },
+        "@wasmcloud/actor-http-server": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/@wasmcloud/actor-http-server/-/actor-http-server-0.1.2.tgz",
+            "integrity": "sha512-eA5pOQqZANoYVcH/gGTyegCZqmPuDHvCt7LeXqfmAcMJ/WOljzG2Tf+jM4NFcL7dNjafzjiGFmY4N5F17FrNfA==",
+            "requires": {
+                "@wapc/as-guest": "^v0.2.1",
+                "@wapc/as-msgpack": "^0.1.11"
+            }
+        },
+        "@wasmcloud/actor-keyvalue": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@wasmcloud/actor-keyvalue/-/actor-keyvalue-0.1.1.tgz",
+            "integrity": "sha512-vYTXDhShxr8mvtlPFWImD4xmdfVSp354pkRgE6PTB41x1/8FA+h3oTESt0G96v7cCRi5TcieZ6Pk8yz3wQdokA==",
+            "requires": {
+                "@wapc/as-guest": "^v0.2.1",
+                "@wapc/as-msgpack": "^0.1.11"
+            }
+        },
         "ansi-regex": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",

--- a/kvcounter-as/package.json
+++ b/kvcounter-as/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kvcounter-as",
-    "version": "0.0.1",
-    "description": "AssemblyScript version of the Rust KVCounter actor",
+    "version": "0.1.0",
+    "description": "AssemblyScript version of the KVCounter actor",
     "main": "index.js",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1",
@@ -10,16 +10,16 @@
         "asbuild:optimized": "asc assembly/index.ts -b build/optimized.wasm -t build/optimized.wat --validate --sourceMap --optimize",
         "asbuild": "npm run asbuild:untouched && npm run asbuild:optimized"
     },
-    "author": "",
+    "author": "wasmCloud Team",
     "license": "Apache-2.0",
     "dependencies": {
-        "wascc-actor-as": "git+https://github.com/wascc/wascc-actor-as",
-        "wapc-guest-as": "git+https://github.com/wapc/wapc-guest-as#v0.2.0",
+        "@wapc/as-guest": "^v0.2.1",
+        "@wapc/as-msgpack": "^0.1.11",
         "assemblyscript-json": "git+https://github.com/nearprotocol/assemblyscript-json"
     },
     "devDependencies": {
+        "assemblyscript": "^0.17.1",
         "graphql-schema-linter": "^0.2.0",
-        "prettier": "^2.0.2",
-        "assemblyscript": "^0.9.4"
+        "prettier": "^2.0.2"
     }
 }

--- a/kvcounter-as/package.json
+++ b/kvcounter-as/package.json
@@ -15,6 +15,9 @@
     "dependencies": {
         "@wapc/as-guest": "^v0.2.1",
         "@wapc/as-msgpack": "^0.1.11",
+        "@wasmcloud/actor-http-server": "^0.1.2",
+        "@wasmcloud/actor-keyvalue": "^0.1.1",
+        "@wasmcloud/actor-core": "^0.1.1",
         "assemblyscript-json": "git+https://github.com/nearprotocol/assemblyscript-json"
     },
     "devDependencies": {

--- a/kvcounter-as/sign.sh
+++ b/kvcounter-as/sign.sh
@@ -1,2 +1,0 @@
-wascap sign build/kvcounter-as.wasm ../../wascc-host/examples/.assets/as-actor.wasm --issuer ../../wascc-host/examples/.assets/act.nk --subject ../../wascc-host/examples/.assets/mod_kvcounter.nk -k -l -s -n "AssemblyScript KV Counter"
-

--- a/kvcounter-as/tsconfig.json
+++ b/kvcounter-as/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "declaration": true,
+    },
+    "extends": "./node_modules/assemblyscript/std/assembly.json",
+    "include": [
+        "./**/*.ts",
+        "src/**/*"
+    ]
+}

--- a/kvcounter/Cargo.lock
+++ b/kvcounter/Cargo.lock
@@ -2,15 +2,13 @@
 # It is not intended for manual editing.
 [[package]]
 name = "actor-core"
-version = "0.1.0"
-source = "git+https://github.com/wascc/actor-interfaces?branch=main#44ea80b92c244dad0ddb6a37c70601347116f982"
+version = "0.2.0"
 dependencies = [
  "lazy_static",
  "log",
  "rmp-serde",
  "serde",
  "serde_bytes",
- "serde_derive",
  "serde_json",
  "wapc-guest",
 ]
@@ -18,7 +16,6 @@ dependencies = [
 [[package]]
 name = "actor-http-server"
 version = "0.1.0"
-source = "git+https://github.com/wascc/actor-interfaces?branch=main#44ea80b92c244dad0ddb6a37c70601347116f982"
 dependencies = [
  "lazy_static",
  "log",
@@ -32,15 +29,13 @@ dependencies = [
 
 [[package]]
 name = "actor-keyvalue"
-version = "0.1.0"
-source = "git+https://github.com/wascc/actor-interfaces?branch=main#44ea80b92c244dad0ddb6a37c70601347116f982"
+version = "0.2.0"
 dependencies = [
  "lazy_static",
  "log",
  "rmp-serde",
  "serde",
  "serde_bytes",
- "serde_derive",
  "serde_json",
  "wapc-guest",
 ]
@@ -53,9 +48,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
 name = "cfg-if"
@@ -71,7 +66,7 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "kvcounter"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "actor-core",
  "actor-http-server",
@@ -88,9 +83,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
 dependencies = [
  "cfg-if",
  "serde",
@@ -135,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "rmp-serde"
-version = "0.14.4"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce7d70c926fe472aed493b902010bccc17fa9f7284145cb8772fd22fdb052d8"
+checksum = "046c5bb3a3728ed6a97d7337e436ec5966fa5e71899c5312c3aa0fda7f949c7f"
 dependencies = [
  "byteorder",
  "rmp",
@@ -152,9 +147,9 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "serde"
-version = "1.0.117"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
+checksum = "166b2349061381baf54a58e4b13c89369feb0ef2eaa57198899e2312aac30aab"
 dependencies = [
  "serde_derive",
 ]
@@ -170,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.117"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
+checksum = "0ca2a8cb5805ce9e3b95435e3765b7b553cecc762d938d409434338386cb5775"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -181,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.59"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
+checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
 dependencies = [
  "itoa",
  "ryu",
@@ -192,9 +187,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.48"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
+checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/kvcounter/Cargo.lock
+++ b/kvcounter/Cargo.lock
@@ -3,6 +3,7 @@
 [[package]]
 name = "actor-core"
 version = "0.2.0"
+source = "git+https://github.com/wasmcloud/actor-interfaces?branch=main#1d029dfba75488792ffe23952368250542e07b01"
 dependencies = [
  "lazy_static",
  "log",
@@ -16,6 +17,7 @@ dependencies = [
 [[package]]
 name = "actor-http-server"
 version = "0.1.0"
+source = "git+https://github.com/wasmcloud/actor-interfaces?branch=main#1d029dfba75488792ffe23952368250542e07b01"
 dependencies = [
  "lazy_static",
  "log",
@@ -30,6 +32,7 @@ dependencies = [
 [[package]]
 name = "actor-keyvalue"
 version = "0.2.0"
+source = "git+https://github.com/wasmcloud/actor-interfaces?branch=main#1d029dfba75488792ffe23952368250542e07b01"
 dependencies = [
  "lazy_static",
  "log",

--- a/kvcounter/Cargo.toml
+++ b/kvcounter/Cargo.toml
@@ -9,9 +9,9 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wapc-guest = "0.4.0"
-actor-core = { path = "../../actor-interfaces/rust/actor-core", features = ["guest"]}
-actor-http-server = { path = "../../actor-interfaces/rust/http-server", features = ["guest"]}
-actor-keyvalue = { path = "../../actor-interfaces/rust/keyvalue", features = ["guest"]}
+actor-keyvalue = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main", features = ["guest"] }
+actor-core = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main", features = ["guest"] }
+actor-http-server = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main", features = ["guest"]}
 serde_json = "1.0.59"
 
 [profile.release]

--- a/kvcounter/Cargo.toml
+++ b/kvcounter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kvcounter"
-version = "0.1.1"
-authors = ["Kevin Hoffman <alothien@gmail.com>"]
+version = "0.2.0"
+authors = ["wasmCloud Team"]
 edition = "2018"
 
 [lib]
@@ -9,9 +9,9 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wapc-guest = "0.4.0"
-actor-core = { git = "https://github.com/wascc/actor-interfaces", branch = "main" }
-actor-http-server = { git = "https://github.com/wascc/actor-interfaces", branch = "main"}
-actor-keyvalue = { git = "https://github.com/wascc/actor-interfaces", branch = "main"}
+actor-core = { path = "../../actor-interfaces/rust/actor-core", features = ["guest"]}
+actor-http-server = { path = "../../actor-interfaces/rust/http-server", features = ["guest"]}
+actor-keyvalue = { path = "../../actor-interfaces/rust/keyvalue", features = ["guest"]}
 serde_json = "1.0.59"
 
 [profile.release]

--- a/kvcounter/README.md
+++ b/kvcounter/README.md
@@ -8,4 +8,4 @@ This actor accepts `GET` requests and for each URL it gets, it will increment a 
 }
 ```
 
-This actor makes use of the HTTP server (`wascc:http_server`) capability and the key-value store capability (`wascc:keyvalue`). As usual, it is worth noting that this actor does _not_ know where its HTTP server comes from, nor does it know which key-value implementation the host runtime has provided.
+This actor makes use of the HTTP server (`wasmcloud:httpserver`) capability and the key-value store capability (`wasmcloud:keyvalue`). As usual, it is worth noting that this actor does _not_ know where its HTTP server comes from, nor does it know which key-value implementation the host runtime has provided.


### PR DESCRIPTION
Part of #5 

This PR updates the `echo`, `kvcounter` and `kvcounter-as` actors to use the applicable `wasmcloud:*` contract IDs, and replaces their dependencies of `wascc_actor` with the appropriate actor-interfaces for the examples. I have verified that `echo` and `kvcounter` are working well to replace their counterparts, however `kvcounter-as` is not yet in a working state. Creating a draft PR for now, I'll convert to a regular PR once I get the assemblyscript KVCounter actor working.