### PR TITLE
Bumping to 0.2.1 with newest interfaces

### DIFF
--- a/echo/Cargo.toml
+++ b/echo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "echo"
-version = "0.2.0"
-authors = ["wasmCloud Team"]
+version = "0.2.1"
+authors = ["wasmcloud Team"]
 edition = "2018"
 
 [lib]
@@ -9,8 +9,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wapc-guest = "0.4.0"
-wasmcloud-actor-core = { version = "0.2.0", features = ["guest"] }
-wasmcloud-actor-http-server = { version = "0.1.0", features = ["guest"]}
+wasmcloud-actor-core = { version = "0.2.2", features = ["guest"] }
+wasmcloud-actor-http-server = { version = "0.1.1", features = ["guest"]}
 serde_json ="1.0.60"
 serde = {version = "1.0.118", features = ["derive"]}
 


### PR DESCRIPTION
The driving reason for this PR is my desire to test updating actors with `wash ctl`, so I'd like to release a new patch version of `echo` with the newest versions of actor interfaces as well.