### PR TITLE
Examples templates require passing build before release, included extras template

### DIFF
--- a/.github/workflows/echo-release.yml
+++ b/.github/workflows/echo-release.yml
@@ -44,6 +44,7 @@ jobs:
         working-directory: ${{ env.working-directory }}
 
   github_release:
+    needs: [cargo_check, clippy_check]
     runs-on: ubuntu-latest
     steps:
     - name: Create Release

--- a/.github/workflows/extras-release.yml
+++ b/.github/workflows/extras-release.yml
@@ -1,0 +1,86 @@
+name: EXTRAS-RELEASE
+
+on:
+  push:
+    tags:
+    - 'extras-v*'
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./extras
+  DESTINATION: target/wasm32-unknown-unknown/release/extras_s.wasm
+  WASH_ISSUER_KEY: ${{ secrets.WASMCLOUD_ACCOUNT_OFFICIAL }}
+  WASH_SUBJECT_KEY: ${{ secrets.WASMCLOUD_EXTRAS }}
+  WASH_REG_USER:  ${{ secrets.AZURECR_PUSH_USER }}
+  WASH_REG_PASSWORD:  ${{ secrets.AZURECR_PUSH_PASSWORD }}
+  REVISION: ${{ github.run_number }}
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Add wasm32-unknown-unknown
+      run: rustup target add wasm32-unknown-unknown
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Run tests
+      run: cargo test --bins --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{ env.working-directory }}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Add wasm32-unknown-unknown
+        run: rustup target add wasm32-unknown-unknown
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{ env.working-directory }}
+
+  github_release:
+    needs: [cargo_check, clippy_check]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: true
+
+  artifact_release:
+    needs: github_release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          curl -s https://packagecloud.io/install/repositories/wasmCloud/core/script.deb.sh | sudo bash
+          sudo apt install wash
+      - name: Add wasm32-unknown-unknown
+        run: rustup target add wasm32-unknown-unknown
+      - name: Build
+        run: cargo build --release
+        working-directory: ${{ env.working-directory }}
+      - name: Wash Sign Claim
+        run: |
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
+          #TODO: SIGN WITH GOOD CAPABILITIES AND CHANGE NAME
+          wash claims sign target/wasm32-unknown-unknown/release/extras.wasm --disable-keygen --name "Extras" --ver $VERSION --rev ${{ env.REVISION }}
+        working-directory: ${{ env.working-directory }}
+      # Push artifact to https://AZURECR/extras:VERSION
+      - name: push-artifact
+        run: |
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
+          URL=${{secrets.AZURECR_PUSH_URL}}/extras:$VERSION
+          wash reg push $URL ${{ env.DESTINATION }}
+        working-directory: ${{ env.working-directory }}

--- a/.github/workflows/extras-release.yml
+++ b/.github/workflows/extras-release.yml
@@ -74,8 +74,7 @@ jobs:
       - name: Wash Sign Claim
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
-          #TODO: SIGN WITH GOOD CAPABILITIES AND CHANGE NAME
-          wash claims sign target/wasm32-unknown-unknown/release/extras.wasm --disable-keygen --name "Extras" --ver $VERSION --rev ${{ env.REVISION }}
+          wash claims sign target/wasm32-unknown-unknown/release/extras.wasm -c wasmcloud:httpserver -c wasmcloud:extras --disable-keygen --name "Extras" --ver $VERSION --rev ${{ env.REVISION }}
         working-directory: ${{ env.working-directory }}
       # Push artifact to https://AZURECR/extras:VERSION
       - name: push-artifact

--- a/.github/workflows/extras.yml
+++ b/.github/workflows/extras.yml
@@ -1,0 +1,43 @@
+name: EXTRAS
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+    - "extras/**"
+  pull_request:
+    branches: [ main ]
+    paths:
+    - "extras/**"
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./extras
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Add wasm32-unknown-unknown
+      run: rustup target add wasm32-unknown-unknown
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Run tests
+      run: cargo test --bins --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{ env.working-directory }}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Add wasm32-unknown-unknown
+        run: rustup target add wasm32-unknown-unknown
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{ env.working-directory }}

--- a/.github/workflows/keyvalue-provider-release.yml
+++ b/.github/workflows/keyvalue-provider-release.yml
@@ -40,6 +40,7 @@ jobs:
         working-directory: ${{ env.working-directory }}
 
   github_release:
+    needs: [cargo_check, clippy_check]
     runs-on: ubuntu-latest
     steps:
     - name: Create Release

--- a/.github/workflows/kvcounter-as-release.yml
+++ b/.github/workflows/kvcounter-as-release.yml
@@ -17,6 +17,7 @@ env:
 
 jobs:
   github_release:
+    needs: [cargo_check, clippy_check]
     runs-on: ubuntu-latest
     steps:
     - name: Create Release

--- a/.github/workflows/kvcounter-release.yml
+++ b/.github/workflows/kvcounter-release.yml
@@ -44,6 +44,7 @@ jobs:
         working-directory: ${{ env.working-directory }}
 
   github_release:
+    needs: [cargo_check, clippy_check]
     runs-on: ubuntu-latest
     steps:
     - name: Create Release

--- a/.github/workflows/logger-release.yml
+++ b/.github/workflows/logger-release.yml
@@ -44,6 +44,7 @@ jobs:
         working-directory: ${{ env.working-directory }}
 
   github_release:
+    needs: [cargo_check, clippy_check]
     runs-on: ubuntu-latest
     steps:
     - name: Create Release

--- a/.github/workflows/subscriber-release.yml
+++ b/.github/workflows/subscriber-release.yml
@@ -44,6 +44,7 @@ jobs:
         working-directory: ${{ env.working-directory }}
 
   github_release:
+    needs: [cargo_check, clippy_check]
     runs-on: ubuntu-latest
     steps:
     - name: Create Release

--- a/.github/workflows/template-release.yml
+++ b/.github/workflows/template-release.yml
@@ -48,6 +48,7 @@ jobs:
         working-directory: ${{ env.working-directory }}
 
   github_release:
+    needs: [cargo_check, clippy_check]
     runs-on: ubuntu-latest
     steps:
     - name: Create Release


### PR DESCRIPTION
Turns out the extras example didn't have a release template so I couldn't release it 😄 

While I was editing them I went ahead and made it so that the release actions had to pass cargo checks and clippy checks before the release would occur.