### PR TITLE
fixed payments interface issue

### DIFF
--- a/ecommerce/payments-interface/Makefile
+++ b/ecommerce/payments-interface/Makefile
@@ -4,6 +4,8 @@ all: deps codegen build
 
 deps:
 
+build:
+
 codegen:
 	wapc generate codegen.yaml
 

--- a/ecommerce/payments-interface/codegen.yaml
+++ b/ecommerce/payments-interface/codegen.yaml
@@ -1,5 +1,5 @@
 schema: payments.widl
 generates:
   src/generated.rs:
-    package: widl-codegen/language/rust
+    module: '@wapc/widl-codegen/rust'
     visitorClass: ModuleVisitor  


### PR DESCRIPTION
The payments interface generator example did not work with the latest version of wapc.