### PR TITLE
Echo body back, increment revision

### DIFF
--- a/actor/echo/Cargo.lock
+++ b/actor/echo/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "echo"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "futures 0.3.17",

--- a/actor/echo/Cargo.toml
+++ b/actor/echo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo"
-version = "0.3.0"
+version = "0.3.1"
 authors = [ "wasmcloud Team" ]
 edition = "2018"
 

--- a/actor/echo/Makefile
+++ b/actor/echo/Makefile
@@ -2,7 +2,7 @@
 
 PROJECT  = echo
 VERSION  = $(shell cargo metadata --no-deps --format-version 1 | jq -r '.packages[] .version' | head -1)
-REVISION = 0
+REVISION = 4
 # list of all contract claims for actor signing (space-separated)
 CLAIMS   = wasmcloud:httpserver
 # registry url for our actor

--- a/actor/echo/src/lib.rs
+++ b/actor/echo/src/lib.rs
@@ -14,7 +14,7 @@ impl HttpServer for EchoActor {
             "method": &value.method,
             "path": &value.path,
             "query_string": &value.query_string,
-            "body": b"".to_vec(),
+            "body": &value.body,
         });
         let resp = HttpResponse {
             body: serde_json::to_vec(&body)


### PR DESCRIPTION
Previously the echo actor would simply echo back an empty vec, but we should echo the body back too. This was causing test failures in https://github.com/wasmCloud/wasmcloud-otp/pull/214