### PR TITLE
add makefile support for call aliases and custom actor name

### DIFF
--- a/build/makefiles/actor.mk
+++ b/build/makefiles/actor.mk
@@ -38,6 +38,7 @@ TARGET_DIR ?= target
 # location of wasm file after build and signing
 DIST_WASM ?= build/$(PROJECT)_s.wasm
 WASM_TARGET ?= wasm32-unknown-unknown
+ACTOR_NAME  ?= $(PROJECT)
 UNSIGNED_WASM = $(TARGET_DIR)/$(WASM_TARGET)/release/$(PROJECT).wasm
 
 # verify all required variables are set
@@ -58,7 +59,8 @@ $(DIST_WASM): $(UNSIGNED_WASM) Makefile
 	@mkdir -p $(dir $@)
 	$(WASH) claims sign $< \
 		$(foreach claim,$(CLAIMS), -c $(claim) ) \
-		--name "$(PROJECT)" --ver $(VERSION) --rev $(REVISION) \
+		--name $(ACTOR_NAME) --ver $(VERSION) --rev $(REVISION) \
+		$(if $(ACTOR_ALIAS),--call-alias $(ACTOR_ALIAS)) \
 		--destination $@
 
 # rules to print file name and path of build target


### PR DESCRIPTION
fixes [wash 170](https://github.com/wasmCloud/wash/issues/170)
adds support for call alias
 (define ACTOR_ALIAS in Makefile)
adds support for actor name
 (define ACTOR_NAME in Makefile), defaults to PROJECT if undefined


Signed-off-by: stevelr <steve@cosmonic.com>