### PR TITLE
fix: timeout and rpc-timeout changed to ms

### DIFF
--- a/actor/echo-messaging/Makefile
+++ b/actor/echo-messaging/Makefile
@@ -18,6 +18,6 @@ MESSAGING_PROVIDER_ID = VADNMSIML2XGO2X4TPIONTIC55R2UUQGPPDZPAVSC2QD7E76CR77SPW7
 
 link:
 	# link to messaging provider
-	wash ctl link --timeout 3 $(shell make actor_id | tail -1) \
+	wash ctl link --timeout-ms 3000 $(shell make actor_id | tail -1) \
 		$(MESSAGING_PROVIDER_ID) wasmcloud:messaging \
 		'URI=nats://localhost:4222' 'SUBSCRIPTION=demo.echo'

--- a/actor/xkcd/Makefile
+++ b/actor/xkcd/Makefile
@@ -22,9 +22,9 @@ HTTPCLIENT_PROVIDER_ID = VD2K2JRF7MFPGGTBXTIGNOJL354GVHDPSD5LUT65ZQMVMZNPMA2ADTO
 link:
 	# link to httpserver and httpclient
 	# because numbergen is a builtin, it doesn't require a link command
-	wash ctl link --timeout 3 $(ACTOR_ID) \
+	wash ctl link --timeout-ms 3000 $(ACTOR_ID) \
 		$(HTTPSERVER_PROVIDER_ID) wasmcloud:httpserver \
 		'config_json={"address":"127.0.0.1:8080"}'
-	wash ctl link --timeout 3 $(ACTOR_ID) \
+	wash ctl link --timeout-ms 3000 $(ACTOR_ID) \
 		$(HTTPCLIENT_PROVIDER_ID) wasmcloud:httpclient
 

--- a/build/makefiles/actor.mk
+++ b/build/makefiles/actor.mk
@@ -82,7 +82,7 @@ push: $(DIST_WASM)
 
 # tell host to start an instance of the actor
 start:
-	$(WASH) ctl start actor $(REG_URL) --timeout 3
+	$(WASH) ctl start actor $(REG_URL) --timeout-ms 3000
 
 # NOT WORKING - live actor updates not working yet
 # update it (should update revision before doing this)
@@ -91,17 +91,17 @@ start:
 #	$(WASH) ctl update actor  \
 #        $(shell $(WASH) ctl get hosts -o json | jq -r ".hosts[0].id") \
 #	    $(shell make --silent actor_id) \
-#	    $(REG_URL) --timeout 3
+#	    $(REG_URL) --timeout-ms 3000
 
 inventory:
 	$(WASH) ctl get inventory $(shell $(WASH) ctl get hosts -o json | jq -r ".hosts[0].id")
 
 ifneq ($(wildcard test-options.json),)
 # if this is a test actor, run its start method
-# project makefile can set RPC_TEST_TIMEOUT to override default
-RPC_TEST_TIMEOUT ?= 2
+# project makefile can set RPC_TEST_TIMEOUT_MS to override default
+RPC_TEST_TIMEOUT_MS ?= 2000
 test::
-	$(WASH) call --test --data test-options.json --rpc-timeout $(TEST_TIMEOUT) \
+	$(WASH) call --test --data test-options.json --rpc-timeout-ms $(RPC_TEST_TIMEOUT_MS) \
 	    $(shell make --silent actor_id) \
 	    Start
 endif

--- a/build/makefiles/provider.mk
+++ b/build/makefiles/provider.mk
@@ -154,7 +154,7 @@ start:
 	$(WASH) ctl start provider $(oci_url) \
 		--host-id $(shell $(WASH) ctl get hosts -o json | jq -r ".hosts[0].id") \
 		--link-name $(link_name) \
-		--timeout 4
+		--timeout-ms 4000
 
 # inspect claims on par file
 inspect: $(dest_par)

--- a/petclinic/actors/clinicapi/actor.mk
+++ b/petclinic/actors/clinicapi/actor.mk
@@ -73,7 +73,7 @@ push: $(DIST_WASM)
 
 # tell host to start an instance of the actor
 start:
-	$(WASH) ctl start actor $(REG_URL) --timeout 3
+	$(WASH) ctl start actor $(REG_URL) --timeout-ms 3000
 
 # NOT WORKING - live actor updates not working yet
 # update it (should update revision before doing this)
@@ -82,18 +82,18 @@ start:
 #	$(WASH) ctl update actor  \
 #        $(shell $(WASH) ctl get hosts -o json | jq -r ".hosts[0].id") \
 #	    $(shell make --silent actor_id) \
-#	    $(REG_URL) --timeout 3
+#	    $(REG_URL) --timeout-ms 3000
 
 inventory:
 	$(WASH) ctl get inventory $(shell $(WASH) ctl get hosts -o json | jq -r ".hosts[0].id")
 
 ifneq ($(wildcard test-options.json),)
 # if this is a test actor, run its start method
-# project makefile can set RPC_TEST_TIMEOUT to override default
-RPC_TEST_TIMEOUT ?= 2
+# project makefile can set RPC_TEST_TIMEOUT_MS to override default
+RPC_TEST_TIMEOUT_MS ?= 2000
 ACTOR_ID=$(shell make --silent actor_id)
 test::
-	$(WASH) call $(ACTOR_ID) --test --data test-options.json --rpc-timeout $(RPC_TEST_TIMEOUT) Start
+	$(WASH) call $(ACTOR_ID) --test --data test-options.json --rpc-timeout-ms $(RPC_TEST_TIMEOUT_MS) Start
 endif
 
 # generate release build

--- a/petclinic/actors/visits/actor.mk
+++ b/petclinic/actors/visits/actor.mk
@@ -73,7 +73,7 @@ push: $(DIST_WASM)
 
 # tell host to start an instance of the actor
 start:
-	$(WASH) ctl start actor $(REG_URL) --timeout 3
+	$(WASH) ctl start actor $(REG_URL) --timeout-ms 3000
 
 # NOT WORKING - live actor updates not working yet
 # update it (should update revision before doing this)
@@ -82,17 +82,17 @@ start:
 #	$(WASH) ctl update actor  \
 #        $(shell $(WASH) ctl get hosts -o json | jq -r ".hosts[0].id") \
 #	    $(shell make actor_id) \
-#	    $(REG_URL) --timeout 3
+#	    $(REG_URL) --timeout-ms 3000
 
 inventory:
 	$(WASH) ctl get inventory $(shell $(WASH) ctl get hosts -o json | jq -r ".hosts[0].id")
 
 ifneq ($(wildcard test-options.json),)
 # if this is a test actor, run its start method
-# project makefile can set RPC_TEST_TIMEOUT to override default
-RPC_TEST_TIMEOUT ?= 2
+# project makefile can set RPC_TEST_TIMEOUT_MS to override default
+RPC_TEST_TIMEOUT_MS ?= 2000
 test::
-	$(WASH) call --test --data test-options.json --rpc-timeout $(TEST_TIMEOUT) \
+	$(WASH) call --test --data test-options.json --rpc-timeout-ms $(RPC_TEST_TIMEOUT_MS) \
 	    $(shell make actor_id) \
 	    Start
 endif

--- a/petclinic/petclinic-interface/rust/src/petclinic.rs
+++ b/petclinic/petclinic-interface/rust/src/petclinic.rs
@@ -158,6 +158,109 @@ pub struct Visit {
 
 pub type VisitList = Vec<Visit>;
 
+/// Description of Petclinic service
+/// wasmbus.actorReceive
+#[async_trait]
+pub trait Petclinic {
+    /// Converts the input string to a result
+    async fn convert<TS: ToString + ?Sized + std::marker::Sync>(
+        &self,
+        ctx: &Context,
+        arg: &TS,
+    ) -> RpcResult<String>;
+}
+
+/// PetclinicReceiver receives messages defined in the Petclinic service trait
+/// Description of Petclinic service
+#[doc(hidden)]
+#[async_trait]
+pub trait PetclinicReceiver: MessageDispatch + Petclinic {
+    async fn dispatch(&self, ctx: &Context, message: &Message<'_>) -> RpcResult<Message<'_>> {
+        match message.method {
+            "Convert" => {
+                let value: String = deserialize(message.arg.as_ref())
+                    .map_err(|e| RpcError::Deser(format!("message '{}': {}", message.method, e)))?;
+                let resp = Petclinic::convert(self, ctx, &value).await?;
+                let buf = serialize(&resp)?;
+                Ok(Message {
+                    method: "Petclinic.Convert",
+                    arg: Cow::Owned(buf),
+                })
+            }
+            _ => Err(RpcError::MethodNotHandled(format!(
+                "Petclinic::{}",
+                message.method
+            ))),
+        }
+    }
+}
+
+/// PetclinicSender sends messages to a Petclinic service
+/// Description of Petclinic service
+/// client for sending Petclinic messages
+#[derive(Debug)]
+pub struct PetclinicSender<T: Transport> {
+    transport: T,
+}
+
+impl<T: Transport> PetclinicSender<T> {
+    /// Constructs a PetclinicSender with the specified transport
+    pub fn via(transport: T) -> Self {
+        Self { transport }
+    }
+
+    pub fn set_timeout(&self, interval: std::time::Duration) {
+        self.transport.set_timeout(interval);
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<'send> PetclinicSender<wasmbus_rpc::provider::ProviderTransport<'send>> {
+    /// Constructs a Sender using an actor's LinkDefinition,
+    /// Uses the provider's HostBridge for rpc
+    pub fn for_actor(ld: &'send wasmbus_rpc::core::LinkDefinition) -> Self {
+        Self {
+            transport: wasmbus_rpc::provider::ProviderTransport::new(ld, None),
+        }
+    }
+}
+#[cfg(target_arch = "wasm32")]
+impl PetclinicSender<wasmbus_rpc::actor::prelude::WasmHost> {
+    /// Constructs a client for actor-to-actor messaging
+    /// using the recipient actor's public key
+    pub fn to_actor(actor_id: &str) -> Self {
+        let transport =
+            wasmbus_rpc::actor::prelude::WasmHost::to_actor(actor_id.to_string()).unwrap();
+        Self { transport }
+    }
+}
+#[async_trait]
+impl<T: Transport + std::marker::Sync + std::marker::Send> Petclinic for PetclinicSender<T> {
+    #[allow(unused)]
+    /// Converts the input string to a result
+    async fn convert<TS: ToString + ?Sized + std::marker::Sync>(
+        &self,
+        ctx: &Context,
+        arg: &TS,
+    ) -> RpcResult<String> {
+        let buf = serialize(&arg.to_string())?;
+        let resp = self
+            .transport
+            .send(
+                ctx,
+                Message {
+                    method: "Petclinic.Convert",
+                    arg: Cow::Borrowed(&buf),
+                },
+                None,
+            )
+            .await?;
+        let value = deserialize(&resp)
+            .map_err(|e| RpcError::Deser(format!("response to {}: {}", "Convert", e)))?;
+        Ok(value)
+    }
+}
+
 /// wasmbus.actorReceive
 #[async_trait]
 pub trait Vets {
@@ -367,109 +470,6 @@ impl<T: Transport + std::marker::Sync + std::marker::Send> Visits for VisitsSend
             .await?;
         let value = deserialize(&resp)
             .map_err(|e| RpcError::Deser(format!("response to {}: {}", "RecordVisit", e)))?;
-        Ok(value)
-    }
-}
-
-/// Description of Petclinic service
-/// wasmbus.actorReceive
-#[async_trait]
-pub trait Petclinic {
-    /// Converts the input string to a result
-    async fn convert<TS: ToString + ?Sized + std::marker::Sync>(
-        &self,
-        ctx: &Context,
-        arg: &TS,
-    ) -> RpcResult<String>;
-}
-
-/// PetclinicReceiver receives messages defined in the Petclinic service trait
-/// Description of Petclinic service
-#[doc(hidden)]
-#[async_trait]
-pub trait PetclinicReceiver: MessageDispatch + Petclinic {
-    async fn dispatch(&self, ctx: &Context, message: &Message<'_>) -> RpcResult<Message<'_>> {
-        match message.method {
-            "Convert" => {
-                let value: String = deserialize(message.arg.as_ref())
-                    .map_err(|e| RpcError::Deser(format!("message '{}': {}", message.method, e)))?;
-                let resp = Petclinic::convert(self, ctx, &value).await?;
-                let buf = serialize(&resp)?;
-                Ok(Message {
-                    method: "Petclinic.Convert",
-                    arg: Cow::Owned(buf),
-                })
-            }
-            _ => Err(RpcError::MethodNotHandled(format!(
-                "Petclinic::{}",
-                message.method
-            ))),
-        }
-    }
-}
-
-/// PetclinicSender sends messages to a Petclinic service
-/// Description of Petclinic service
-/// client for sending Petclinic messages
-#[derive(Debug)]
-pub struct PetclinicSender<T: Transport> {
-    transport: T,
-}
-
-impl<T: Transport> PetclinicSender<T> {
-    /// Constructs a PetclinicSender with the specified transport
-    pub fn via(transport: T) -> Self {
-        Self { transport }
-    }
-
-    pub fn set_timeout(&self, interval: std::time::Duration) {
-        self.transport.set_timeout(interval);
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl<'send> PetclinicSender<wasmbus_rpc::provider::ProviderTransport<'send>> {
-    /// Constructs a Sender using an actor's LinkDefinition,
-    /// Uses the provider's HostBridge for rpc
-    pub fn for_actor(ld: &'send wasmbus_rpc::core::LinkDefinition) -> Self {
-        Self {
-            transport: wasmbus_rpc::provider::ProviderTransport::new(ld, None),
-        }
-    }
-}
-#[cfg(target_arch = "wasm32")]
-impl PetclinicSender<wasmbus_rpc::actor::prelude::WasmHost> {
-    /// Constructs a client for actor-to-actor messaging
-    /// using the recipient actor's public key
-    pub fn to_actor(actor_id: &str) -> Self {
-        let transport =
-            wasmbus_rpc::actor::prelude::WasmHost::to_actor(actor_id.to_string()).unwrap();
-        Self { transport }
-    }
-}
-#[async_trait]
-impl<T: Transport + std::marker::Sync + std::marker::Send> Petclinic for PetclinicSender<T> {
-    #[allow(unused)]
-    /// Converts the input string to a result
-    async fn convert<TS: ToString + ?Sized + std::marker::Sync>(
-        &self,
-        ctx: &Context,
-        arg: &TS,
-    ) -> RpcResult<String> {
-        let buf = serialize(&arg.to_string())?;
-        let resp = self
-            .transport
-            .send(
-                ctx,
-                Message {
-                    method: "Petclinic.Convert",
-                    arg: Cow::Borrowed(&buf),
-                },
-                None,
-            )
-            .await?;
-        let value = deserialize(&resp)
-            .map_err(|e| RpcError::Deser(format!("response to {}: {}", "Convert", e)))?;
         Ok(value)
     }
 }

--- a/petclinic/run.sh
+++ b/petclinic/run.sh
@@ -227,8 +227,8 @@ drop_db() {
 start_providers() {
     local _host_id=$(host_id)
 
-  	wash ctl start provider $HTTPSERVER_REF --link-name default --host-id $_host_id --timeout 15
-	wash ctl start provider $SQLDB_REF      --link-name default --host-id $_host_id --timeout 15
+  	wash ctl start provider $HTTPSERVER_REF --link-name default --host-id $_host_id --timeout-ms 15000
+	wash ctl start provider $SQLDB_REF      --link-name default --host-id $_host_id --timeout-ms 15000
 }
 
 # base-64 encode file into a string


### PR DESCRIPTION
Related to a naming convention change a week ago:
https://github.com/wasmCloud/wash/pull/198

I ran `make && make test` locally.
This regenerated petclinic.rs file. I opted to keep it, but
holler if this needs to be a separate PR.