### PR TITLE
fix(petclinic): clippy warnings

### DIFF
--- a/petclinic/actors/clinicapi/src/lib.rs
+++ b/petclinic/actors/clinicapi/src/lib.rs
@@ -159,7 +159,7 @@ async fn create_pet(ctx: &Context, owner_id: &str, pet: Pet) -> RpcResult<HttpRe
             ctx,
             &AddPetRequest {
                 owner_id: oid,
-                pet: pet,
+                pet,
             },
         )
         .await?
@@ -254,7 +254,7 @@ fn get_pet_type(pts: &[PetType], id: u64) -> AugmentedPetType {
             name: "Unknown".to_string(),
         },
         |p| AugmentedPetType {
-            id: id,
+            id,
             name: p.name.to_string(),
         },
     )

--- a/petclinic/actors/customers/src/db.rs
+++ b/petclinic/actors/customers/src/db.rs
@@ -25,12 +25,11 @@ const TABLE_PETS: &str = "pets";
 const TABLE_PETTYPES: &str = "pettypes";
 
 static REGEX: Lazy<regex::Regex> = Lazy::new(|| {
-    let re = regex::Regex::new(r"^[-a-zA-Z0-9 ,._/]+$").unwrap();
-    re
+    regex::Regex::new(r"^[-a-zA-Z0-9 ,._/]+$").unwrap()
 });
 
 fn check_safety(tag: &str, uncertain_input: &str) -> Result<(), std::io::Error> {
-    if !REGEX.is_match(&uncertain_input) {
+    if !REGEX.is_match(uncertain_input) {
         return Err(std::io::Error::new(
             std::io::ErrorKind::Other,
             format!("{} contains invalid characters", tag),
@@ -90,7 +89,7 @@ pub(crate) struct PetType {
 pub(crate) async fn delete_pet(ctx: &Context, client: &Db, id: u64) -> Result<(), SqlDbError> {
     let resp = client
         .execute(
-            &ctx,
+            ctx,
             &format!(
                 r#"
             delete from {} where id = {}
@@ -119,7 +118,7 @@ pub(crate) async fn add_pet(
 
     let resp = client
         .execute(
-            &ctx,
+            ctx,
             &format!(
                 r#"
             insert into {} (id, pettype, name, bday, bmonth, byear, ownerid)
@@ -149,10 +148,10 @@ pub(crate) async fn create_owner(
     arg: &petclinic_interface::Owner,
 ) -> Result<(), SqlDbError> {
     let owner = Owner::try_from(arg.clone())
-        .map_err(|_e| SqlDbError::new("parse", "Invalid owner".into()))?;
+        .map_err(|_e| SqlDbError::new("parse", "Invalid new owner".into()))?;
     let resp = client
         .execute(
-            &ctx,
+            ctx,
             &format!(
                 r#"
                 insert into {} (id, address, city, email, firstname, lastname, telephone)
@@ -182,7 +181,7 @@ pub(crate) async fn find_owner(
     id: u64,
 ) -> Result<Option<Owner>, SqlDbError> {
     let resp=client.fetch(
-        &ctx,
+        ctx,
         &format!(
             "select id, address, city, email, firstname, lastname, telephone from {} where id = {}",
             TABLE_OWNERS, id
@@ -205,7 +204,7 @@ pub(crate) async fn find_pet(
 ) -> Result<Option<Pet>, SqlDbError> {
     let resp = client
         .fetch(
-            &ctx,
+            ctx,
             &format!(
                 "select id, pettype, name, bday, bmonth, byear, ownerid from {} where id = {}",
                 TABLE_PETS, id
@@ -225,7 +224,7 @@ pub(crate) async fn find_pet(
 pub(crate) async fn list_all_owners(ctx: &Context, client: &Db) -> Result<Vec<Owner>, SqlDbError> {
     let resp = client
         .fetch(
-            &ctx,
+            ctx,
             &format!(
                 "select id, address, city, email, firstname, lastname, telephone from {}",
                 TABLE_OWNERS
@@ -243,7 +242,7 @@ pub(crate) async fn list_all_pet_types(
     client: &Db,
 ) -> Result<Vec<PetType>, SqlDbError> {
     let resp = client
-        .fetch(&ctx, &format!("select id, name FROM {}", TABLE_PETTYPES))
+        .fetch(ctx, &format!("select id, name FROM {}", TABLE_PETTYPES))
         .await?;
     let rows: Vec<PetType> = safe_decode(&resp)?;
     Ok(rows)
@@ -257,7 +256,7 @@ pub(crate) async fn list_pets_by_owner(
 ) -> Result<Vec<Pet>, SqlDbError> {
     let resp = client
         .fetch(
-            &ctx,
+            ctx,
             &format!(
                 "select id, pettype, name, bday, bmonth, byear, ownerid from {}
                 where ownerid = {}",
@@ -283,7 +282,7 @@ pub(crate) async fn update_pet(
 
     let resp = client
         .execute(
-            &ctx,
+            ctx,
             &format!(
                 r#"
             update {} 
@@ -323,7 +322,7 @@ pub(crate) async fn update_owner(
 
     let resp = client
         .execute(
-            &ctx,
+            ctx,
             &format!(
                 r#"
                 update {}
@@ -425,10 +424,10 @@ impl TryFrom<petclinic_interface::Owner> for Owner {
     type Error = std::io::Error;
 
     fn try_from(arg: petclinic_interface::Owner) -> Result<Self, Self::Error> {
-        let address = arg.address.unwrap_or("".into());
-        let city = arg.city.unwrap_or("".into());
-        let lastname = arg.last_name.unwrap_or("".into());
-        let telephone = arg.telephone.unwrap_or("".into());
+        let address = arg.address.unwrap_or_else(|| "".into());
+        let city = arg.city.unwrap_or_else(|| "".into());
+        let lastname = arg.last_name.unwrap_or_else(|| "".into());
+        let telephone = arg.telephone.unwrap_or_else(|| "".into());
 
         check_safety("address", &address)?;
         check_safety("city", &city)?;

--- a/petclinic/actors/customers/src/lib.rs
+++ b/petclinic/actors/customers/src/lib.rs
@@ -19,7 +19,7 @@ struct CustomersActor {}
 impl Customers for CustomersActor {
     async fn create_owner(&self, ctx: &Context, owner: &Owner) -> RpcResult<CreateOwnerReply> {
         let db = SqlDbSender::new();
-        Ok(match db::create_owner(&ctx, &db, owner).await {
+        Ok(match db::create_owner(ctx, &db, owner).await {
             Ok(_) => CreateOwnerReply {
                 id: owner.id,
                 success: true,
@@ -37,19 +37,19 @@ impl Customers for CustomersActor {
     async fn find_owner(&self, ctx: &Context, arg: &u64) -> RpcResult<FindOwnerReply> {
         let db = SqlDbSender::new();
         Ok(FindOwnerReply {
-            owner: db::find_owner(&ctx, &db, *arg).await?.map(|o| o.into()),
+            owner: db::find_owner(ctx, &db, *arg).await?.map(|o| o.into()),
         })
     }
 
     async fn list_owners(&self, ctx: &Context) -> RpcResult<OwnersList> {
         let db = SqlDbSender::new();
-        let owners = db::list_all_owners(&ctx, &db).await?;
+        let owners = db::list_all_owners(ctx, &db).await?;
         Ok(owners.iter().cloned().map(|o| o.into()).collect())
     }
 
     async fn update_owner(&self, ctx: &Context, arg: &Owner) -> RpcResult<UpdateOwnerReply> {
         let db = SqlDbSender::new();
-        Ok(match db::update_owner(&ctx, &db, arg).await {
+        Ok(match db::update_owner(ctx, &db, arg).await {
             Ok(_) => UpdateOwnerReply { success: true },
             Err(e) => {
                 error!("Failed to update owner: {}", e);
@@ -60,13 +60,13 @@ impl Customers for CustomersActor {
 
     async fn list_pet_types(&self, ctx: &Context) -> RpcResult<PetTypeList> {
         let db = SqlDbSender::new();
-        let pettypes = db::list_all_pet_types(&ctx, &db).await?;
+        let pettypes = db::list_all_pet_types(ctx, &db).await?;
         Ok(pettypes.iter().cloned().map(|o| o.into()).collect())
     }
 
     async fn add_pet(&self, ctx: &Context, arg: &AddPetRequest) -> RpcResult<bool> {
         let db = SqlDbSender::new();
-        Ok(match db::add_pet(&ctx, &db, arg.owner_id, &arg.pet).await {
+        Ok(match db::add_pet(ctx, &db, arg.owner_id, &arg.pet).await {
             Ok(_) => true,
             Err(e) => {
                 error!("Failed to add pet: {}", e);
@@ -77,7 +77,7 @@ impl Customers for CustomersActor {
 
     async fn remove_pet(&self, ctx: &Context, arg: &u64) -> RpcResult<bool> {
         let db = SqlDbSender::new();
-        Ok(match db::delete_pet(&ctx, &db, *arg).await {
+        Ok(match db::delete_pet(ctx, &db, *arg).await {
             Ok(_) => true,
             Err(e) => {
                 error!("Failed to remove pet: {}", e);
@@ -88,7 +88,7 @@ impl Customers for CustomersActor {
 
     async fn update_pet(&self, ctx: &Context, arg: &Pet) -> RpcResult<bool> {
         let db = SqlDbSender::new();
-        Ok(match db::update_pet(&ctx, &db, arg).await {
+        Ok(match db::update_pet(ctx, &db, arg).await {
             Ok(_) => true,
             Err(e) => {
                 error!("Failed to update pet: {}", e);
@@ -99,7 +99,7 @@ impl Customers for CustomersActor {
 
     async fn list_pets(&self, ctx: &Context, arg: &u64) -> RpcResult<PetList> {
         let db = SqlDbSender::new();
-        let pets = db::list_pets_by_owner(&ctx, &db, *arg).await?;
+        let pets = db::list_pets_by_owner(ctx, &db, *arg).await?;
         Ok(pets.iter().cloned().map(|o| o.into()).collect())
     }
 

--- a/petclinic/actors/vets/src/db.rs
+++ b/petclinic/actors/vets/src/db.rs
@@ -40,7 +40,7 @@ impl From<DbVet> for petclinic_interface::Vet {
             last_name: source.lastname,
             specialties: source
                 .specialties
-                .split(",")
+                .split(',')
                 .map(|s| s.to_string())
                 .collect::<Vec<_>>(),
         }

--- a/petclinic/actors/visits/src/db.rs
+++ b/petclinic/actors/visits/src/db.rs
@@ -7,12 +7,11 @@ use wasmcloud_interface_sqldb::{FetchResult, SqlDb, SqlDbError, minicbor};
 const TABLE_VISITS: &str = "visits";
 
 static REGEX: Lazy<regex::Regex> = Lazy::new(|| {
-    let re = regex::Regex::new(r"^[-a-zA-Z0-9 ,._/]+$").unwrap();
-    re
+    regex::Regex::new(r"^[-a-zA-Z0-9 ,._/]+$").unwrap()
 });
 
 fn check_safety(tag: &str, uncertain_input: &str) -> Result<(), std::io::Error> {
-    if !REGEX.is_match(&uncertain_input) {
+    if !REGEX.is_match(uncertain_input) {
         return Err(std::io::Error::new(
             std::io::ErrorKind::Other,
             format!("{} contains invalid characters", tag),
@@ -84,7 +83,7 @@ pub(crate) async fn record_visit(
 
     let resp = client
         .execute(
-            &ctx,
+            ctx,
             &format!(
                 r#"
             insert into {} (day, month, year, description, petid, vetid, ownerid, hour, minute)


### PR DESCRIPTION
Fixed all clippy warnings for the various rust modules within the petclinic example.

I noticed that there isn't a github workflow for this project. Looking at the template, I would need the ability to create a secret for this org to create a working action workflow (`secrets.WASMCLOUD_EXAMPLE`). I skipped this but it would be worth doing, at least for the rust-check with clippy.