### PR TITLE
Fix petclinic 500 errors and UI crashes

### DIFF
--- a/petclinic/actors/customers/Cargo.toml
+++ b/petclinic/actors/customers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "customers"
-version = "0.2.0"
+version = "0.2.1"
 authors = [ "" ]
 edition = "2021"
 

--- a/petclinic/actors/customers/src/db.rs
+++ b/petclinic/actors/customers/src/db.rs
@@ -290,8 +290,7 @@ pub(crate) async fn update_pet(
                     name = '{}',
                     bday = {},
                     bmonth = {},
-                    byear = {},
-                    ownerid = {}
+                    byear = {}
             WHERE id = {}
             "#,
                 TABLE_PETS,
@@ -300,7 +299,6 @@ pub(crate) async fn update_pet(
                 pet.bday,
                 pet.bmonth,
                 pet.byear,
-                pet.ownerid,
                 pet.id
             ),
         )

--- a/petclinic/actors/visits/Cargo.toml
+++ b/petclinic/actors/visits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "visits"
-version = "0.2.0"
+version = "0.2.1"
 authors = [ "wasmCloud Team" ]
 edition = "2021"
 

--- a/petclinic/actors/visits/src/db.rs
+++ b/petclinic/actors/visits/src/db.rs
@@ -118,7 +118,6 @@ impl From<DbVisit> for petclinic_interface::Visit {
                 year: source.year as _,
             },
             description: source.description,
-            owner_id: source.ownerid,
             pet_id: source.petid,
             time: petclinic_interface::Time {
                 hour: source.hour as _,

--- a/petclinic/petclinic-interface/rust/src/petclinic.rs
+++ b/petclinic/petclinic-interface/rust/src/petclinic.rs
@@ -143,9 +143,6 @@ pub struct Visit {
     /// Description of the visit
     #[serde(default)]
     pub description: String,
-    /// The ID of the owner for this visit
-    #[serde(rename = "ownerId")]
-    pub owner_id: u64,
     /// The ID of the pet involved in the visit
     #[serde(rename = "petId")]
     pub pet_id: u64,
@@ -283,94 +280,6 @@ impl<T: Transport + std::marker::Sync + std::marker::Send> Visits for VisitsSend
     }
 }
 
-/// wasmbus.actorReceive
-#[async_trait]
-pub trait Vets {
-    async fn list_vets(&self, ctx: &Context) -> RpcResult<VetList>;
-}
-
-/// VetsReceiver receives messages defined in the Vets service trait
-#[doc(hidden)]
-#[async_trait]
-pub trait VetsReceiver: MessageDispatch + Vets {
-    async fn dispatch(&self, ctx: &Context, message: &Message<'_>) -> RpcResult<Message<'_>> {
-        match message.method {
-            "ListVets" => {
-                let resp = Vets::list_vets(self, ctx).await?;
-                let buf = serialize(&resp)?;
-                Ok(Message {
-                    method: "Vets.ListVets",
-                    arg: Cow::Owned(buf),
-                })
-            }
-            _ => Err(RpcError::MethodNotHandled(format!(
-                "Vets::{}",
-                message.method
-            ))),
-        }
-    }
-}
-
-/// VetsSender sends messages to a Vets service
-/// client for sending Vets messages
-#[derive(Debug)]
-pub struct VetsSender<T: Transport> {
-    transport: T,
-}
-
-impl<T: Transport> VetsSender<T> {
-    /// Constructs a VetsSender with the specified transport
-    pub fn via(transport: T) -> Self {
-        Self { transport }
-    }
-
-    pub fn set_timeout(&self, interval: std::time::Duration) {
-        self.transport.set_timeout(interval);
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl<'send> VetsSender<wasmbus_rpc::provider::ProviderTransport<'send>> {
-    /// Constructs a Sender using an actor's LinkDefinition,
-    /// Uses the provider's HostBridge for rpc
-    pub fn for_actor(ld: &'send wasmbus_rpc::core::LinkDefinition) -> Self {
-        Self {
-            transport: wasmbus_rpc::provider::ProviderTransport::new(ld, None),
-        }
-    }
-}
-#[cfg(target_arch = "wasm32")]
-impl VetsSender<wasmbus_rpc::actor::prelude::WasmHost> {
-    /// Constructs a client for actor-to-actor messaging
-    /// using the recipient actor's public key
-    pub fn to_actor(actor_id: &str) -> Self {
-        let transport =
-            wasmbus_rpc::actor::prelude::WasmHost::to_actor(actor_id.to_string()).unwrap();
-        Self { transport }
-    }
-}
-#[async_trait]
-impl<T: Transport + std::marker::Sync + std::marker::Send> Vets for VetsSender<T> {
-    #[allow(unused)]
-    async fn list_vets(&self, ctx: &Context) -> RpcResult<VetList> {
-        let buf = *b"";
-        let resp = self
-            .transport
-            .send(
-                ctx,
-                Message {
-                    method: "Vets.ListVets",
-                    arg: Cow::Borrowed(&buf),
-                },
-                None,
-            )
-            .await?;
-        let value = deserialize(&resp)
-            .map_err(|e| RpcError::Deser(format!("response to {}: {}", "ListVets", e)))?;
-        Ok(value)
-    }
-}
-
 /// Description of Petclinic service
 /// wasmbus.actorReceive
 #[async_trait]
@@ -470,6 +379,94 @@ impl<T: Transport + std::marker::Sync + std::marker::Send> Petclinic for Petclin
             .await?;
         let value = deserialize(&resp)
             .map_err(|e| RpcError::Deser(format!("response to {}: {}", "Convert", e)))?;
+        Ok(value)
+    }
+}
+
+/// wasmbus.actorReceive
+#[async_trait]
+pub trait Vets {
+    async fn list_vets(&self, ctx: &Context) -> RpcResult<VetList>;
+}
+
+/// VetsReceiver receives messages defined in the Vets service trait
+#[doc(hidden)]
+#[async_trait]
+pub trait VetsReceiver: MessageDispatch + Vets {
+    async fn dispatch(&self, ctx: &Context, message: &Message<'_>) -> RpcResult<Message<'_>> {
+        match message.method {
+            "ListVets" => {
+                let resp = Vets::list_vets(self, ctx).await?;
+                let buf = serialize(&resp)?;
+                Ok(Message {
+                    method: "Vets.ListVets",
+                    arg: Cow::Owned(buf),
+                })
+            }
+            _ => Err(RpcError::MethodNotHandled(format!(
+                "Vets::{}",
+                message.method
+            ))),
+        }
+    }
+}
+
+/// VetsSender sends messages to a Vets service
+/// client for sending Vets messages
+#[derive(Debug)]
+pub struct VetsSender<T: Transport> {
+    transport: T,
+}
+
+impl<T: Transport> VetsSender<T> {
+    /// Constructs a VetsSender with the specified transport
+    pub fn via(transport: T) -> Self {
+        Self { transport }
+    }
+
+    pub fn set_timeout(&self, interval: std::time::Duration) {
+        self.transport.set_timeout(interval);
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<'send> VetsSender<wasmbus_rpc::provider::ProviderTransport<'send>> {
+    /// Constructs a Sender using an actor's LinkDefinition,
+    /// Uses the provider's HostBridge for rpc
+    pub fn for_actor(ld: &'send wasmbus_rpc::core::LinkDefinition) -> Self {
+        Self {
+            transport: wasmbus_rpc::provider::ProviderTransport::new(ld, None),
+        }
+    }
+}
+#[cfg(target_arch = "wasm32")]
+impl VetsSender<wasmbus_rpc::actor::prelude::WasmHost> {
+    /// Constructs a client for actor-to-actor messaging
+    /// using the recipient actor's public key
+    pub fn to_actor(actor_id: &str) -> Self {
+        let transport =
+            wasmbus_rpc::actor::prelude::WasmHost::to_actor(actor_id.to_string()).unwrap();
+        Self { transport }
+    }
+}
+#[async_trait]
+impl<T: Transport + std::marker::Sync + std::marker::Send> Vets for VetsSender<T> {
+    #[allow(unused)]
+    async fn list_vets(&self, ctx: &Context) -> RpcResult<VetList> {
+        let buf = *b"";
+        let resp = self
+            .transport
+            .send(
+                ctx,
+                Message {
+                    method: "Vets.ListVets",
+                    arg: Cow::Borrowed(&buf),
+                },
+                None,
+            )
+            .await?;
+        let value = deserialize(&resp)
+            .map_err(|e| RpcError::Deser(format!("response to {}: {}", "ListVets", e)))?;
         Ok(value)
     }
 }

--- a/petclinic/petclinic-interface/visits.smithy
+++ b/petclinic/petclinic-interface/visits.smithy
@@ -65,7 +65,4 @@ structure Visit {
     /// ID of the veterinarian who saw the given pet on this visit
     @required
     vetId: U64,
-    /// The ID of the owner for this visit
-    @required     
-    ownerId: U64
 }

--- a/petclinic/petclinic-ui/package-lock.json
+++ b/petclinic/petclinic-ui/package-lock.json
@@ -9899,9 +9899,9 @@
       }
     },
     "lilconfig": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.3.tgz",
-      "integrity": "sha512-EHKqr/+ZvdKCifpNrJCKxBTgk5XupZA3y/aCPY9mxfgBzmgh93Mt/WqjjQ38oMxXuvDokaKiM3lAgvSH2sjtHg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.4.tgz",
+      "integrity": "sha512-bfTIN7lEsiooCocSISTWXkiWJkRqtL9wYtYy+8EK3Y41qh3mpwPU0ycTOgjdY9ErwXCc8QyrQp82bdL0Xkm9yA==",
       "dev": true
     },
     "lines-and-columns": {
@@ -11085,6 +11085,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
     },
     "picomatch": {
       "version": "2.3.0",
@@ -12496,20 +12502,20 @@
           "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
           "dev": true
         },
-        "nanocolors": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.2.10.tgz",
-          "integrity": "sha512-i+EDWGsJClQwR/bhLIG/CObZZwaYaS5qt+yjxZbfV+77QiNHNzE9nj4d9Ut1TGZ0R0eSwPcQWzReASzXuw/7oA==",
+        "nanoid": {
+          "version": "3.1.30",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
+          "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
           "dev": true
         },
         "postcss": {
-          "version": "8.3.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.8.tgz",
-          "integrity": "sha512-GT5bTjjZnwDifajzczOC+r3FI3Cu+PgPvrsjhQdRqa2kTJ4968/X9CUce9xttIB0xOs5c6xf0TCWZo/y9lF6bA==",
+          "version": "8.3.11",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.11.tgz",
+          "integrity": "sha512-hCmlUAIlUiav8Xdqw3Io4LcpA1DOt7h3LSTAC4G6JGHFFaWzI6qvFt9oilvl8BmkbBRX1IhM90ZAmpk68zccQA==",
           "dev": true,
           "requires": {
-            "nanocolors": "^0.2.2",
-            "nanoid": "^3.1.25",
+            "nanoid": "^3.1.30",
+            "picocolors": "^1.0.0",
             "source-map-js": "^0.6.2"
           }
         }
@@ -14583,9 +14589,9 @@
       }
     },
     "tailwindcss": {
-      "version": "npm:@tailwindcss/postcss7-compat@2.2.16",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss7-compat/-/postcss7-compat-2.2.16.tgz",
-      "integrity": "sha512-k+f6DL1KxG0d2dEUILxytWpHRBPMagQ8wUdH5bJUzbmv7TPd3yriR+nSOXy2Hcvt79cP3Lgc5J6oPjO4PNyRLg==",
+      "version": "npm:@tailwindcss/postcss7-compat@2.2.17",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss7-compat/-/postcss7-compat-2.2.17.tgz",
+      "integrity": "sha512-3h2svqQAqYHxRZ1KjsJjZOVTQ04m29LjfrLjXyZZEJuvUuJN+BCIF9GI8vhE1s0plS0mogd6E6YLg6mu4Wv/Vw==",
       "dev": true,
       "requires": {
         "arg": "^5.0.1",
@@ -14681,12 +14687,23 @@
           }
         },
         "glob-parent": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.1.tgz",
-          "integrity": "sha512-kEVjS71mQazDBHKcsq4E9u/vUzaLcw1A8EtUeydawvIWQCJM0qQ08G1H7/XTjFUulla6XQiDOG6MXSaG0HDKog==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+          "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
           "dev": true,
           "requires": {
-            "is-glob": "^4.0.1"
+            "is-glob": "^4.0.3"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+              "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.1"
+              }
+            }
           }
         },
         "has-flag": {

--- a/petclinic/petclinic-ui/src/Modal.js
+++ b/petclinic/petclinic-ui/src/Modal.js
@@ -292,7 +292,7 @@ export function VisitsModal(props) {
       minute: 0,
     }
     visit.vetId = 1;
-    const response = await api.createPetVisit(props.owner.id, props.pet.id, visit).catch((err) => { return err })
+    await api.createPetVisit(props.owner.id, props.pet.id, visit).catch((err) => { return err })
     setVisits([visit, ...visits]);
     setVisit({})
   }

--- a/petclinic/petclinic-ui/src/Modal.js
+++ b/petclinic/petclinic-ui/src/Modal.js
@@ -2,6 +2,9 @@ import React, { useEffect, useState } from 'react';
 import api from './Api';
 
 function parseDateString(day, month, year) {
+  if (isNaN(day) || isNaN(month) || isNaN(year)) {
+    return ""
+  }
   return new Date(Date.parse(`${year}-${month}-${day}`)).toISOString().split('T')[0]
 }
 

--- a/petclinic/petclinic-ui/src/Modal.js
+++ b/petclinic/petclinic-ui/src/Modal.js
@@ -187,6 +187,7 @@ export function PetModal(props) {
     }
     if (e.target.id === 'petType') {
       val = parseInt(e.target.value);
+      pet.petType = val
     }
     setPet({
       ...pet,
@@ -225,7 +226,7 @@ export function PetModal(props) {
           Pet Type
         </label>
         <select
-          value={pet.petType ? pet.petType.id : ''}
+          value={pet.petType ? pet.petType.id ? pet.petType.id : pet.petType : ''}
           onChange={(e) => onChange(e)}
           className="shadow appearance-none border w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
           id="petType">

--- a/petclinic/petclinic-ui/src/Owner.js
+++ b/petclinic/petclinic-ui/src/Owner.js
@@ -53,6 +53,7 @@ export default class Owner extends Component {
 
   async addOrEditPet(pet) {
     if (this.state.pet) {
+      pet.petType = Number.isInteger(pet.petType) ? pet.petType : pet.petType.id
       await api.updatePet(this.props.owner.id, pet.id, pet).catch((err) => { return err })
     } else {
       await api.createPet(this.props.owner.id, pet).catch((err) => { return err })
@@ -169,6 +170,7 @@ export default class Owner extends Component {
             modalTitle={this.state.pet ? 'Edit Pet' : 'Add Pet'}
             setShowModal={(val) => closeModal(val)}>
             <PetModal
+              owner={this.state.owner}
               pet={this.state.pet}
               petCallback={(pet) => {
                 if (!this.state.pet) {

--- a/petclinic/petclinic-ui/src/Owner.js
+++ b/petclinic/petclinic-ui/src/Owner.js
@@ -37,7 +37,7 @@ export default class Owner extends Component {
   }
 
   async updateOwner(owner) {
-    const response = await api.updateOwner(this.props.owner.id, owner).catch((err) => { return err })
+    await api.updateOwner(this.props.owner.id, owner).catch((err) => { return err })
     this.setState({
       owner: owner,
       showModal: false
@@ -52,11 +52,10 @@ export default class Owner extends Component {
   }
 
   async addOrEditPet(pet) {
-    let response;
     if (this.state.pet) {
-      response = await api.updatePet(this.props.owner.id, pet.id, pet).catch((err) => { return err })
+      await api.updatePet(this.props.owner.id, pet.id, pet).catch((err) => { return err })
     } else {
-      response = await api.createPet(this.props.owner.id, pet).catch((err) => { return err })
+      await api.createPet(this.props.owner.id, pet).catch((err) => { return err })
     }
     this.setState({
       pets: !this.state.pet ?

--- a/petclinic/petclinic-ui/src/Owners.js
+++ b/petclinic/petclinic-ui/src/Owners.js
@@ -30,7 +30,7 @@ export default function Owners() {
 
   const addOwner = async (owner) => {
     owner.id = owners.length + 1;
-    const response = await api.createOwner(owner).catch((err) => { return err })
+    await api.createOwner(owner).catch((err) => { return err })
     setOwners([owner, ...owners])
   }
 

--- a/petclinic/petclinic-ui/src/Owners.js
+++ b/petclinic/petclinic-ui/src/Owners.js
@@ -67,7 +67,7 @@ export default function Owners() {
             </tr>
           </thead>
           <tbody>
-            {owners.map((owner, idx) => {
+            {owners && owners.length > 0 && owners.map((owner, idx) => {
               return (
                 <tr onClick={() => setOwner(owner)} key={idx} className="border cursor-pointer">
                   <td className="px-8 py-4">{`${owner.firstName} ${owner.lastName}`}</td>

--- a/petclinic/petclinic-ui/src/PetTypes.js
+++ b/petclinic/petclinic-ui/src/PetTypes.js
@@ -28,7 +28,7 @@ export default function PetTypes() {
         </tr>
       </thead>
       <tbody>
-        {petTypes.map((petType, idx) => {
+        {petTypes && petTypes.length > 0 && petTypes.map((petType, idx) => {
           return (
             <tr onClick={() => console.log(petType)} key={idx} className="border cursor-pointer">
               <td className="px-8 py-4">{petType.name}</td>

--- a/petclinic/petclinic-ui/src/Vets.js
+++ b/petclinic/petclinic-ui/src/Vets.js
@@ -31,7 +31,7 @@ export default function Vets() {
         </tr>
       </thead>
       <tbody>
-        {vets && vets.map((vet, idx) => {
+        {vets && vets.length > 0 && vets.map((vet, idx) => {
           return (
             <tr onClick={() => console.log(vet)} key={idx} className="border cursor-pointer">
               <td className="px-8 py-4">{`${vet.firstName} ${vet.lastName}`}</td>


### PR DESCRIPTION
This PR addresses a number of miscellaneous potential errors that you could encounter across the petclinic example

1. 500 errors editing a pet due to missing an owner ID
2. 500 errors adding a visit due to not including an owner ID (interface updated)
3. UI crashes when typing dates due to NaN errors
4. Incorrect shape of `pet.petType` state, would cause the pet type to be incorrectly selected after first creation in `Edit Pet`
5. When customers or vets actors are down, react would crash. Now we handle that case and simply display an empty table

Lastly, I addressed a few warnings for unused `response` variables