### PR TITLE
Petclinic CI/CD

### DIFF
--- a/.github/workflows/petclinic.yml
+++ b/.github/workflows/petclinic.yml
@@ -106,7 +106,6 @@ jobs:
       fail-fast: false
       matrix:
         artifact-name: [clinicapi, customers, vets, visits]
-
     steps:
       - name: Download signed actor
         uses: actions/download-artifact@v2
@@ -122,30 +121,47 @@ jobs:
           prerelease: true
           draft: false
 
-  # artifact_release:
-  #   needs: build_artifact
-  #   if: startswith(github.ref, 'refs/tags/') # Only run on tag push
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Download signed actor
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         name: wasmcloud-actor
-  #         path: ${{ env.working-directory }}/build
+  artifact_release:
+    needs: actors_build_check 
+    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        working-directory:
+          - petclinic/actors/clinicapi
+          - petclinic/actors/customers
+          - petclinic/actors/vets
+          - petclinic/actors/visits
+        include:
+          - working-directory: petclinic/actors/clinicapi
+            artifact-name: clinicapi
+          - working-directory: petclinic/actors/customers
+            artifact-name: customers
+          - working-directory: petclinic/actors/vets
+            artifact-name: vets
+          - working-directory: petclinic/actors/visits
+            artifact-name: visits
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download signed actor
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.artifact-name }}
+          path: ${{ matrix.working-directory}}/build
 
-  #     - name: Determine artifact metadata
-  #       run: |
-  #         echo "oci-repository=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')" >> $GITHUB_ENV
-  #         echo "oci-version=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')" >> $GITHUB_ENV
-  #       working-directory: ${{ env.working-directory }}
+      - name: Determine artifact metadata
+        run: |
+          echo "oci-repository=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')" >> $GITHUB_ENV
+          echo "oci-version=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')" >> $GITHUB_ENV
+        working-directory: ${{ matrix.working-directory }}
 
-  #     - name: Push actor to AzureCR
-  #       uses: wasmcloud/common-actions/oci-artifact-release@main
-  #       with:
-  #         artifact-path: ${{ env.working-directory }}/build/${{ env.oci-repository }}_s.wasm
-  #         oci-url: ${{ secrets.AZURECR_PUSH_URL }}
-  #         oci-repository: ${{ env.oci-repository }}
-  #         oci-version: ${{ env.oci-version }}
-  #         oci-username: ${{ secrets.AZURECR_PUSH_USER }}
-  #         oci-password: ${{ secrets.AZURECR_PUSH_PASSWORD }}
+      - name: Push actor to AzureCR
+        uses: wasmcloud/common-actions/oci-artifact-release@main
+        with:
+          artifact-path: ${{ env.working-directory }}/build/${{ env.oci-repository }}_s.wasm
+          oci-url: ${{ secrets.AZURECR_PUSH_URL }}
+          oci-repository: ${{ env.oci-repository }}
+          oci-version: ${{ env.oci-version }}
+          oci-username: ${{ secrets.AZURECR_PUSH_USER }}
+          oci-password: ${{ secrets.AZURECR_PUSH_PASSWORD }}

--- a/.github/workflows/petclinic.yml
+++ b/.github/workflows/petclinic.yml
@@ -15,13 +15,19 @@ on:
 env:
   CARGO_TERM_COLOR: always
   WASH_ISSUER_KEY: ${{ secrets.WASMCLOUD_ACCOUNT_OFFICIAL }}
-  working-directory: petclinic/actors
-  #TODO: change per-actor
-  WASH_SUBJECT_KEY: ${{ secrets.WASMCLOUD_EXAMPLE }}
 
 jobs:
-  clinicapi_rust_check:
+  rust_check:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        working-directory:
+          - petclinic/actors/clinicapi
+          - petclinic/actors/customers
+          - petclinic/actors/vets
+          - petclinic/actors/visits
+          - petclinic/petclinic-interface/rust
     steps:
       - uses: actions/checkout@v2
       # If your integration tests require nats or redis, run them here
@@ -30,63 +36,7 @@ jobs:
       - id: rust-check-action
         uses: wasmcloud/common-actions/rust-check@main
         with:
-          working-directory: ${{ env.working-directory }}/clinicapi
-          # The `--doc` is required for wasm, as cargo cannot execute wasm tests by default
-          test-options: "--verbose --doc"
-
-  customers_rust_check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      # If your integration tests require nats or redis, run them here
-      - name: Add wasm32-unknown-unknown
-        run: rustup target add wasm32-unknown-unknown
-      - id: rust-check-action
-        uses: wasmcloud/common-actions/rust-check@main
-        with:
-          working-directory: ${{ env.working-directory }}/customers
-          # The `--doc` is required for wasm, as cargo cannot execute wasm tests by default
-          test-options: "--verbose --doc"
-
-  vets_rust_check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      # If your integration tests require nats or redis, run them here
-      - name: Add wasm32-unknown-unknown
-        run: rustup target add wasm32-unknown-unknown
-      - id: rust-check-action
-        uses: wasmcloud/common-actions/rust-check@main
-        with:
-          working-directory: ${{ env.working-directory }}/vets
-          # The `--doc` is required for wasm, as cargo cannot execute wasm tests by default
-          test-options: "--verbose --doc"
-
-  visits_rust_check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      # If your integration tests require nats or redis, run them here
-      - name: Add wasm32-unknown-unknown
-        run: rustup target add wasm32-unknown-unknown
-      - id: rust-check-action
-        uses: wasmcloud/common-actions/rust-check@main
-        with:
-          working-directory: ${{ env.working-directory }}/visits
-          # The `--doc` is required for wasm, as cargo cannot execute wasm tests by default
-          test-options: "--verbose --doc"
-
-  interface_rust_check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      # If your integration tests require nats or redis, run them here
-      - name: Add wasm32-unknown-unknown
-        run: rustup target add wasm32-unknown-unknown
-      - id: rust-check-action
-        uses: wasmcloud/common-actions/rust-check@main
-        with:
-          working-directory: petclinic/petclinic-interface/rust
+          working-directory: ${{ matrix.working-directory }}
           # The `--doc` is required for wasm, as cargo cannot execute wasm tests by default
           test-options: "--verbose --doc"
 
@@ -101,26 +51,60 @@ jobs:
         run: npm run build
         working-directory: petclinic/petclinic-ui
 
-  # build_artifact:
-  #   needs: rust_check
-  #   if: startswith(github.ref, 'refs/tags/') # Only run on tag push
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: wasmcloud/common-actions/install-wash@main
+  build_artifact:
+    needs: rust_check
+    #TODO: comment this back in after converting to ready for review
+    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        working-directory:
+          - petclinic/actors/clinicapi
+          - petclinic/actors/customers
+          - petclinic/actors/vets
+          - petclinic/actors/visits
+        include:
+          - working-directory: petclinic/actors/clinicapi
+            wasm-filename: clinicapi.wasm
+          - working-directory: petclinic/actors/customers
+            wasm-filename: customers.wasm
+          - working-directory: petclinic/actors/vets
+            wasm-filename: vets.wasm
+          - working-directory: petclinic/actors/visits
+            wasm-filename: visits.wasm
+    steps:
+      - uses: actions/checkout@v2
+      - uses: wasmcloud/common-actions/install-wash@main
 
-  #     - name: Add wasm32-unknown-unknown
-  #       run: rustup target add wasm32-unknown-unknown
+      - name: Add wasm32-unknown-unknown
+        run: rustup target add wasm32-unknown-unknown
 
-  #     - name: Build wasmcloud actor
-  #       run: make
-  #       working-directory: ${{ env.working-directory }}
+      # Note: This step is only required because secrets cannot be used in the `include` block
+      - name: Set wash subject key (clinicapi)
+        if: ${{ matrix.working-directory == 'petclinic/actors/clinicapi' }}
+        run: echo "WASH_SUBJECT_KEY=${{ secrets.WASMCLOUD_PETCLINIC_CLINICAPI }}" > $GITHUB_ENV
+      - name: Set wash subject key (customers)
+        if: ${{ matrix.working-directory == 'petclinic/actors/customers' }}
+        run: echo "WASH_SUBJECT_KEY=${{ secrets.WASMCLOUD_PETCLINIC_CUSTOMERS }}" > $GITHUB_ENV
+      - name: Set wash subject key (vets)
+        if: ${{ matrix.working-directory == 'petclinic/actors/vets' }}
+        run: echo "WASH_SUBJECT_KEY=${{ secrets.WASMCLOUD_PETCLINIC_VETS }}" > $GITHUB_ENV
+      - name: Set wash subject key (clinicapi)
+        if: ${{ matrix.working-directory == 'petclinic/actors/visits' }}
+        run: echo "WASH_SUBJECT_KEY=${{ secrets.WASMCLOUD_PETCLINIC_VISITS }}" > $GITHUB_ENV
 
-  #     - name: Upload signed actor to GH Actions
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: wasmcloud-actor
-  #         path: ${{ env.working-directory }}/build/*.wasm
+      - name: Build wasmcloud actor
+        env:
+          WASH_SUBJECT_KEY: ${{ env.WASH_SUBJECT_KEY }}
+        run: make
+        working-directory: ${{ matrix.working-directory }}
+
+      - name: Upload signed actor to GH Actions
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.wasm-filename }}
+          path: ${{ matrix.working-directory }}/build/*.wasm
 
   # github_release:
   #   if: startswith(github.ref, 'refs/tags/') # Only run on tag push

--- a/.github/workflows/petclinic.yml
+++ b/.github/workflows/petclinic.yml
@@ -1,0 +1,167 @@
+name: Petclinic
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "petclinic/**"
+    tags:
+      - "petclinic-v*"
+  pull_request:
+    branches: [main]
+    paths:
+      - "petclinic/**"
+
+env:
+  CARGO_TERM_COLOR: always
+  WASH_ISSUER_KEY: ${{ secrets.WASMCLOUD_ACCOUNT_OFFICIAL }}
+  working-directory: petclinic/actors
+  #TODO: change per-actor
+  WASH_SUBJECT_KEY: ${{ secrets.WASMCLOUD_EXAMPLE }}
+
+jobs:
+  clinicapi_rust_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # If your integration tests require nats or redis, run them here
+      - name: Add wasm32-unknown-unknown
+        run: rustup target add wasm32-unknown-unknown
+      - id: rust-check-action
+        uses: wasmcloud/common-actions/rust-check@main
+        with:
+          working-directory: ${{ env.working-directory }}/clinicapi
+          # The `--doc` is required for wasm, as cargo cannot execute wasm tests by default
+          test-options: "--verbose --doc"
+
+  customers_rust_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # If your integration tests require nats or redis, run them here
+      - name: Add wasm32-unknown-unknown
+        run: rustup target add wasm32-unknown-unknown
+      - id: rust-check-action
+        uses: wasmcloud/common-actions/rust-check@main
+        with:
+          working-directory: ${{ env.working-directory }}/customers
+          # The `--doc` is required for wasm, as cargo cannot execute wasm tests by default
+          test-options: "--verbose --doc"
+
+  vets_rust_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # If your integration tests require nats or redis, run them here
+      - name: Add wasm32-unknown-unknown
+        run: rustup target add wasm32-unknown-unknown
+      - id: rust-check-action
+        uses: wasmcloud/common-actions/rust-check@main
+        with:
+          working-directory: ${{ env.working-directory }}/vets
+          # The `--doc` is required for wasm, as cargo cannot execute wasm tests by default
+          test-options: "--verbose --doc"
+
+  visits_rust_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # If your integration tests require nats or redis, run them here
+      - name: Add wasm32-unknown-unknown
+        run: rustup target add wasm32-unknown-unknown
+      - id: rust-check-action
+        uses: wasmcloud/common-actions/rust-check@main
+        with:
+          working-directory: ${{ env.working-directory }}/visits
+          # The `--doc` is required for wasm, as cargo cannot execute wasm tests by default
+          test-options: "--verbose --doc"
+
+  interface_rust_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # If your integration tests require nats or redis, run them here
+      - name: Add wasm32-unknown-unknown
+        run: rustup target add wasm32-unknown-unknown
+      - id: rust-check-action
+        uses: wasmcloud/common-actions/rust-check@main
+        with:
+          working-directory: petclinic/petclinic-interface/rust
+          # The `--doc` is required for wasm, as cargo cannot execute wasm tests by default
+          test-options: "--verbose --doc"
+
+  ui_build_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Test NPM build
+        run: npm run build
+        working-directory: petclinic/petclinic-ui
+
+  # build_artifact:
+  #   needs: rust_check
+  #   if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: wasmcloud/common-actions/install-wash@main
+
+  #     - name: Add wasm32-unknown-unknown
+  #       run: rustup target add wasm32-unknown-unknown
+
+  #     - name: Build wasmcloud actor
+  #       run: make
+  #       working-directory: ${{ env.working-directory }}
+
+  #     - name: Upload signed actor to GH Actions
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: wasmcloud-actor
+  #         path: ${{ env.working-directory }}/build/*.wasm
+
+  # github_release:
+  #   if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+  #   needs: build_artifact
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Download signed actor
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         name: wasmcloud-actor
+  #         path: ${{ env.working-directory }}/build
+
+  #     - name: Release
+  #       uses: softprops/action-gh-release@v1
+  #       with:
+  #         files: ${{ env.working-directory }}/build/*.wasm
+  #         token: ${{ secrets.GITHUB_TOKEN }}
+  #         prerelease: true
+  #         draft: false
+
+  # artifact_release:
+  #   needs: build_artifact
+  #   if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Download signed actor
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         name: wasmcloud-actor
+  #         path: ${{ env.working-directory }}/build
+
+  #     - name: Determine artifact metadata
+  #       run: |
+  #         echo "oci-repository=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')" >> $GITHUB_ENV
+  #         echo "oci-version=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')" >> $GITHUB_ENV
+  #       working-directory: ${{ env.working-directory }}
+
+  #     - name: Push actor to AzureCR
+  #       uses: wasmcloud/common-actions/oci-artifact-release@main
+  #       with:
+  #         artifact-path: ${{ env.working-directory }}/build/${{ env.oci-repository }}_s.wasm
+  #         oci-url: ${{ secrets.AZURECR_PUSH_URL }}
+  #         oci-repository: ${{ env.oci-repository }}
+  #         oci-version: ${{ env.oci-version }}
+  #         oci-username: ${{ secrets.AZURECR_PUSH_USER }}
+  #         oci-password: ${{ secrets.AZURECR_PUSH_PASSWORD }}

--- a/.github/workflows/petclinic.yml
+++ b/.github/workflows/petclinic.yml
@@ -17,28 +17,14 @@ env:
   WASH_ISSUER_KEY: ${{ secrets.WASMCLOUD_ACCOUNT_OFFICIAL }}
 
 jobs:
-  rust_check:
+  interface_build_check:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        working-directory:
-          - petclinic/actors/clinicapi
-          - petclinic/actors/customers
-          - petclinic/actors/vets
-          - petclinic/actors/visits
-          - petclinic/petclinic-interface/rust
     steps:
       - uses: actions/checkout@v2
-      # If your integration tests require nats or redis, run them here
-      - name: Add wasm32-unknown-unknown
-        run: rustup target add wasm32-unknown-unknown
       - id: rust-check-action
         uses: wasmcloud/common-actions/rust-check@main
         with:
-          working-directory: ${{ matrix.working-directory }}
-          # The `--doc` is required for wasm, as cargo cannot execute wasm tests by default
-          test-options: "--verbose --doc"
+          working-directory: petclinic/petclinic-interface/rust
 
   ui_build_check:
     runs-on: ubuntu-latest
@@ -51,10 +37,7 @@ jobs:
         run: npm run build
         working-directory: petclinic/petclinic-ui
 
-  build_artifact:
-    needs: rust_check
-    #TODO: comment this back in after converting to ready for review
-    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+  actors_build_check:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -66,19 +49,28 @@ jobs:
           - petclinic/actors/visits
         include:
           - working-directory: petclinic/actors/clinicapi
-            wasm-filename: clinicapi.wasm
+            artifact-name: clinicapi
           - working-directory: petclinic/actors/customers
-            wasm-filename: customers.wasm
+            artifact-name: customers
           - working-directory: petclinic/actors/vets
-            wasm-filename: vets.wasm
+            artifact-name: vets
           - working-directory: petclinic/actors/visits
-            wasm-filename: visits.wasm
+            artifact-name: visits
     steps:
       - uses: actions/checkout@v2
       - uses: wasmcloud/common-actions/install-wash@main
 
       - name: Add wasm32-unknown-unknown
         run: rustup target add wasm32-unknown-unknown
+
+      - id: rust-check-action
+        uses: wasmcloud/common-actions/rust-check@main
+        with:
+          working-directory: ${{ matrix.working-directory }}
+          build-options: "--release"
+          clippy-options: "--release"
+          # The `--doc` is required for wasm, as cargo cannot execute wasm tests by default
+          test-options: "--release --doc"
 
       # Note: This step is only required because secrets cannot be used in the `include` block
       - name: Set wash subject key (clinicapi)
@@ -90,40 +82,45 @@ jobs:
       - name: Set wash subject key (vets)
         if: ${{ matrix.working-directory == 'petclinic/actors/vets' }}
         run: echo "WASH_SUBJECT_KEY=${{ secrets.WASMCLOUD_PETCLINIC_VETS }}" > $GITHUB_ENV
-      - name: Set wash subject key (clinicapi)
+      - name: Set wash subject key (visits)
         if: ${{ matrix.working-directory == 'petclinic/actors/visits' }}
         run: echo "WASH_SUBJECT_KEY=${{ secrets.WASMCLOUD_PETCLINIC_VISITS }}" > $GITHUB_ENV
 
       - name: Build wasmcloud actor
-        env:
-          WASH_SUBJECT_KEY: ${{ env.WASH_SUBJECT_KEY }}
+        if: startswith(github.ref, 'refs/tags/') # Only run on tag push
         run: make
         working-directory: ${{ matrix.working-directory }}
 
       - name: Upload signed actor to GH Actions
+        if: startswith(github.ref, 'refs/tags/') # Only run on tag push
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.wasm-filename }}
+          name: ${{ matrix.artifact-name }}
           path: ${{ matrix.working-directory }}/build/*.wasm
 
-  # github_release:
-  #   if: startswith(github.ref, 'refs/tags/') # Only run on tag push
-  #   needs: build_artifact
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Download signed actor
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         name: wasmcloud-actor
-  #         path: ${{ env.working-directory }}/build
+  github_release:
+    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    needs: actors_build_check 
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        artifact-name: [clinicapi, customers, vets, visits]
 
-  #     - name: Release
-  #       uses: softprops/action-gh-release@v1
-  #       with:
-  #         files: ${{ env.working-directory }}/build/*.wasm
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         prerelease: true
-  #         draft: false
+    steps:
+      - name: Download signed actor
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.artifact-name }}
+          path: build
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: build/*.wasm
+          token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: true
+          draft: false
 
   # artifact_release:
   #   needs: build_artifact

--- a/.github/workflows/petclinic.yml
+++ b/.github/workflows/petclinic.yml
@@ -94,6 +94,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Install NPM deps
+        run: npm install
+        working-directory: petclinic/petclinic-ui
       - name: Test NPM build
         run: npm run build
         working-directory: petclinic/petclinic-ui

--- a/.github/workflows/petclinic.yml
+++ b/.github/workflows/petclinic.yml
@@ -159,7 +159,7 @@ jobs:
       - name: Push actor to AzureCR
         uses: wasmcloud/common-actions/oci-artifact-release@main
         with:
-          artifact-path: ${{ env.working-directory }}/build/${{ env.oci-repository }}_s.wasm
+          artifact-path: ${{ matrix.working-directory }}/build/${{ env.oci-repository }}_s.wasm
           oci-url: ${{ secrets.AZURECR_PUSH_URL }}
           oci-repository: ${{ env.oci-repository }}
           oci-version: ${{ env.oci-version }}

--- a/petclinic/Makefile
+++ b/petclinic/Makefile
@@ -10,4 +10,3 @@ inventory:
 	wash ctl get inventory $(shell wash ctl get hosts -o json | jq -r ".hosts[0].id")
 
 .PHONY: all push start test clean
-

--- a/petclinic/actors/clinicapi/Cargo.toml
+++ b/petclinic/actors/clinicapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clinicapi"
-version = "0.2.0"
+version = "0.2.1"
 authors = [ "wasmCloud Team" ]
 edition = "2021"
 

--- a/petclinic/actors/clinicapi/src/lib.rs
+++ b/petclinic/actors/clinicapi/src/lib.rs
@@ -155,13 +155,7 @@ async fn delete_pet(ctx: &Context, _owner_id: &str, pet_id: &str) -> RpcResult<H
 async fn create_pet(ctx: &Context, owner_id: &str, pet: Pet) -> RpcResult<HttpResponse> {
     let oid: u64 = owner_id.parse().unwrap_or(0);
     if CustomersSender::to_actor(CUSTOMERS_ACTOR)
-        .add_pet(
-            ctx,
-            &AddPetRequest {
-                owner_id: oid,
-                pet,
-            },
-        )
+        .add_pet(ctx, &AddPetRequest { owner_id: oid, pet })
         .await?
     {
         Ok(HttpResponse::default())

--- a/petclinic/actors/customers/src/db.rs
+++ b/petclinic/actors/customers/src/db.rs
@@ -295,13 +295,7 @@ pub(crate) async fn update_pet(
                     byear = {}
             WHERE id = {}
             "#,
-                TABLE_PETS,
-                pet.pettype,
-                pet.name,
-                pet.bday,
-                pet.bmonth,
-                pet.byear,
-                pet.id
+                TABLE_PETS, pet.pettype, pet.name, pet.bday, pet.bmonth, pet.byear, pet.id
             ),
         )
         .await?;

--- a/petclinic/actors/vets/Cargo.toml
+++ b/petclinic/actors/vets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vets"
-version = "0.2.0"
+version = "0.2.1"
 authors = [ "wasmCloud Team" ]
 edition = "2021"
 

--- a/petclinic/petclinic-interface/rust/Cargo.toml
+++ b/petclinic/petclinic-interface/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petclinic-interface"
-version = "0.2.0"
+version = "0.2.1"
 description = "Pet Clinic Actor Interface"
 authors = [ "wasmcCloud Team" ]
 edition = "2018"


### PR DESCRIPTION
Our petclinic demo is getting increasingly refined and popular, starting this PR to get a proper build/test/release pipeline prepared for the actors used in the demo.

This PR includes actions to:
1. Build, format check, lint, test, and sign all four actors involved in the petclinic demo with a matrix strategy
2. Build, format check, lint, and test the petclinic interface
3. Build the UI, check for warnings and errors
4. Create a Github release with our signed petclinic actors attached
5. Release signed actors to AzureCR

**NOTE** The way the release action is setup is such that each tag will release _all_ actors involved in the demo. This is for simplicity, and so if an actor's version in `Cargo.toml` is not changed then it will be re-published to the existing tag. I would recommend just keeping all of the actors at the same version to keep the demo easy-to-understand anyways, so that you always know to start actors with version `v0.2.4`, for example.

You can see a slightly trimmed down (due to not having org secrets) successful run of this [here](https://github.com/brooksmtownsend/examples/actions/runs/1525871183) and the associated github release [here](https://github.com/brooksmtownsend/examples/releases/tag/petclinic-v0.2.1)

After this is merged, we should be able to push the tag `petclinic-v0.2.1`, and release all 4 actors to AzureCR, signed and tagged at `v0.2.1`