### PR TITLE
feat(*): Adds wadm examples for our most commonly used example actors

### DIFF
--- a/actor/echo/README.md
+++ b/actor/echo/README.md
@@ -5,5 +5,3 @@ a handler for the wasmcloud:httpserver capability contract.
 
 For each http request, the actor returns a json-formatted
 string containing fields from the request.
-
-

--- a/actor/echo/wadm.yaml
+++ b/actor/echo/wadm.yaml
@@ -1,0 +1,39 @@
+# This is a full example of how to run the echo actor exposed with an HTTP server. Using this
+# example requires you to have WADM running: https://github.com/wasmCloud/wadm/tree/main/wadm. You
+# can deploy this example with two simple commands:
+#
+# `wash app put wadm.yaml`
+# `wash app deploy echo 0.0.1`
+
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: echo
+  annotations:
+    version: v0.0.1
+    description: "wasmCloud echo Example"
+spec:
+  components:
+    - name: echo
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/echo:0.3.5
+      traits:
+        - type: linkdef
+          properties:
+            target: httpserver
+            values:
+              ADDRESS: 127.0.0.1:8082
+        - type: spreadscaler
+          properties:
+            replicas: 1
+
+    - name: httpserver
+      type: capability
+      properties:
+        image: wasmcloud.azurecr.io/httpserver:0.16.2
+        contract: wasmcloud:httpserver
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1

--- a/actor/kvcounter/wadm.yaml
+++ b/actor/kvcounter/wadm.yaml
@@ -1,0 +1,56 @@
+# This is a full example of how to run the kvcounter actor exposed with an HTTP server. Using this
+# example requires you to have a Redis server running locally (though the linkdef can be modified to
+# use a Redis server you have running elsewhere) and WADM running:
+# https://github.com/wasmCloud/wadm/tree/main/wadm. You can deploy this example with two simple
+# commands:
+#
+# `wash app put wadm.yaml`
+# `wash app deploy kvcounter 0.0.1`
+
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: kvcounter
+  annotations:
+    version: v0.0.1
+    description: "wasmCloud Key Value Counter Example"
+spec:
+  components:
+    - name: kvcounter
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/kvcounter:0.3.4
+      traits:
+        - type: linkdef
+          properties:
+            target: redis
+            values:
+              URL: redis://0.0.0.0:6379/
+        - type: linkdef
+          properties:
+            target: httpserver
+            values:
+              ADDRESS: 127.0.0.1:8081
+        - type: spreadscaler
+          properties:
+            replicas: 1
+
+    - name: httpserver
+      type: capability
+      properties:
+        image: wasmcloud.azurecr.io/httpserver:0.16.2
+        contract: wasmcloud:httpserver
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1
+
+    - name: redis
+      type: capability
+      properties:
+        image: wasmcloud.azurecr.io/kvredis:0.16.3
+        contract: wasmcloud:keyvalue
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1

--- a/petclinic/.gitignore
+++ b/petclinic/.gitignore
@@ -6,3 +6,4 @@
 .psql_root
 .secrets
 sql_config.json
+populated_wadm.yaml

--- a/petclinic/docker/docker-compose.yml
+++ b/petclinic/docker/docker-compose.yml
@@ -84,7 +84,7 @@ services:
       - 55681:55681 # otlp http  
 
   wasmcloud:
-    image: wasmcloud/wasmcloud_host:0.55.1
+    image: wasmcloud/wasmcloud_host:0.56.0
     depends_on: 
       - nats
     environment:
@@ -112,7 +112,7 @@ services:
     depends_on:
       - "nats"
       - "redis"
-    image: wasmcloud.azurecr.io/wadm:0.1.0
+    image: wasmcloud.azurecr.io/wadm:0.3.0
     environment:
       - WADM_NATS_HOST=nats
       - WADM_REDIS_HOST=redis

--- a/petclinic/wadm.yaml
+++ b/petclinic/wadm.yaml
@@ -1,0 +1,129 @@
+# This is a full example of how to run the petclinic example. Using this example requires you to
+# have WADM running: https://github.com/wasmCloud/wadm/tree/main/wadm and a host labeled with
+# `app=petclinic`. You can deploy this example with two simple commands:
+#
+# `wash app put wadm.yaml`
+# `wash app deploy petclinic 0.0.1`
+
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: petclinic
+  annotations:
+    version: v0.0.1
+    description: "wasmCloud Pet Clinic Sample"
+spec:
+  components:
+    - name: ui
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/ui:0.3.2
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1
+            spread:
+              - name: uiclinicapp
+                requirements:
+                  app: petclinic
+
+    - name: customers
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/customers:0.3.1
+      traits:
+        - type: linkdef
+          properties:
+            target: postgres
+            values:
+              uri: postgres://user:pass@your.db.host.com/petclinic
+        - type: spreadscaler
+          properties:
+            replicas: 1
+            spread:
+              - name: customersclinicapp
+                requirements:
+                  app: petclinic
+
+    - name: vets
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/vets:0.3.1
+      traits:
+        - type: linkdef
+          properties:
+            target: postgres
+            values:
+              uri: postgres://user:pass@your.db.host.com/petclinic
+        - type: spreadscaler
+          properties:
+            replicas: 1
+            spread:
+              - name: vetsclinicapp
+                requirements:
+                  app: petclinic
+
+    - name: visits
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/visits:0.3.1
+      traits:
+        - type: linkdef
+          properties:
+            target: postgres
+            values:
+              uri: postgres://user:pass@your.db.host.com/petclinic
+
+        - type: spreadscaler
+          properties:
+            replicas: 1
+            spread:
+              - name: visitsclinicapp
+                requirements:
+                  app: petclinic
+
+    - name: clinicapi
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/clinicapi:0.3.1
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1
+            spread:
+              - name: clinicapp
+                requirements:
+                  app: petclinic
+        - type: linkdef
+          properties:
+            target: httpserver
+            values:
+              address: 0.0.0.0:8080
+
+    - name: httpserver
+      type: capability
+      properties:
+        image: wasmcloud.azurecr.io/httpserver:0.16.2
+        contract: wasmcloud:httpserver
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1
+            spread:
+              - name: httpserverspread
+                requirements:
+                  app: petclinic
+
+    - name: postgres
+      type: capability
+      properties:
+        image: wasmcloud.azurecr.io/sqldb-postgres:0.3.1
+        contract: wasmcloud:sqldb
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1
+            spread:
+              - name: postgresspread
+                requirements:
+                  app: petclinic


### PR DESCRIPTION
Note that this purposefully doesn't add full documentation to READMEs
because setting up wadm is an extra step right now. Once we add support
for it in `wash up` by default, we can add the instructions for running
in wadm. As an intermediate step, instructions were added as a comment
to the top of the wadm manifests