### PR TITLE
add registryType to Credential

### DIFF
--- a/configservice/Cargo.lock
+++ b/configservice/Cargo.lock
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "configservice"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "atty",
  "lazy_static",

--- a/configservice/Cargo.toml
+++ b/configservice/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "configservice"
 description = "An example wasmCloud configuration service"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/configservice/src/main.rs
+++ b/configservice/src/main.rs
@@ -151,6 +151,8 @@ struct Credential {
     pub token: Option<String>,
     pub username: Option<String>,
     pub password: Option<String>,
+    #[serde(rename = "registryType")]
+    pub registry_type: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
This adds `registryType` to `Credential`, which is a required field on the interface now: https://github.com/wasmCloud/interfaces/blob/main/configservice/config-service.smithy#L72

Signed-off-by: Connor Smith <connor@cosmonic.com>