### PR TITLE
wadm manifests for each actor example

### DIFF
--- a/actor/animal-image-downloader/wadm.yaml
+++ b/actor/animal-image-downloader/wadm.yaml
@@ -39,7 +39,7 @@ spec:
     - name: httpclient
       type: capability
       properties:
-        image: wasmcloud.azurecr.io/httpclient:0.5.3
+        image: wasmcloud.azurecr.io/httpclient:0.6.0
         contract: wasmcloud:httpclient
     - name: blobstore
       type: capability

--- a/actor/animal-image-downloader/wadm.yaml
+++ b/actor/animal-image-downloader/wadm.yaml
@@ -10,7 +10,7 @@ kind: Application
 metadata:
   name: animal-image-downloader
   annotations:
-    version: v0.0.1
+    version: v0.0.3
     description: "wasmCloud Animal Image Downloader Example"
 spec:
   components:
@@ -42,14 +42,26 @@ spec:
       properties:
         image: wasmcloud.azurecr.io/httpclient:0.5.3
         contract: wasmcloud:httpclient
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1
     - name: blobstore
       type: capability
       properties:
         image: wasmcloud.azurecr.io/blobstore_fs:0.1.0
         contract: wasmcloud:blobstore
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1
     - name: messaging
       type: capability
       properties:
         image: wasmcloud.azurecr.io/nats_messaging:0.16.3
         contract: wasmcloud:messaging
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1
 

--- a/actor/animal-image-downloader/wadm.yaml
+++ b/actor/animal-image-downloader/wadm.yaml
@@ -1,0 +1,55 @@
+# This is a full example of how to run the animal image downloader.
+# This requires you to have WADM running: https://github.com/wasmCloud/wadm/
+# You can deploy this example with two simple commands:
+#
+# `wash app put wadm.yaml`
+# `wash app deploy animal-image-downloader`
+
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: animal-image-downloader
+  annotations:
+    version: v0.0.1
+    description: "wasmCloud Animal Image Downloader Example"
+spec:
+  components:
+    - name: animal-image-downloader
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/animal-image-downloader:0.1.1
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1
+        - type: linkdef
+          properties:
+            target: httpclient
+        - type: linkdef
+          properties:
+            target: blobstore
+            values:
+              ROOT: "/tmp"
+        - type: linkdef
+          properties:
+            target: messaging
+            values:
+              SUBSCRIPTION: "wasmcloud.animal.*"
+
+    # Capability Providers 
+    - name: httpclient
+      type: capability
+      properties:
+        image: wasmcloud.azurecr.io/httpclient:0.5.3
+        contract: wasmcloud:httpclient
+    - name: blobstore
+      type: capability
+      properties:
+        image: wasmcloud.azurecr.io/blobstore_fs:0.1.0
+        contract: wasmcloud:blobstore
+    - name: messaging
+      type: capability
+      properties:
+        image: wasmcloud.azurecr.io/nats_messaging:0.16.3
+        contract: wasmcloud:messaging
+

--- a/actor/blobby/wadm.yaml
+++ b/actor/blobby/wadm.yaml
@@ -1,4 +1,4 @@
-# This is a full example of how to run the animal image downloader.
+# This is a full example of how to run the blobby example.
 # This requires you to have WADM running: https://github.com/wasmCloud/wadm/
 # You can deploy this example with a simple command:
 #
@@ -7,47 +7,39 @@
 apiVersion: core.oam.dev/v1beta1
 kind: Application
 metadata:
-  name: animal
+  name: blobby
   annotations:
     version: v0.0.1
-    description: "wasmCloud Animal Image Downloader Example"
+    description: "wasmCloud Blobby Example"
 spec:
   components:
-    - name: animal-image-downloader
+    - name: blobby
       type: actor
       properties:
-        image: wasmcloud.azurecr.io/animal-image-downloader:0.1.1
+        image: wasmcloud.azurecr.io/blobby:0.2.0
       traits:
         - type: spreadscaler
           properties:
             replicas: 1
         - type: linkdef
           properties:
-            target: httpclient
+            target: httpserver
+            values:
+              ADDRESS: 0.0.0.0:8080
         - type: linkdef
           properties:
             target: blobstore
             values:
               ROOT: "/tmp"
-        - type: linkdef
-          properties:
-            target: messaging
-            values:
-              SUBSCRIPTION: "wasmcloud.animal.*"
 
     # Capability Providers
-    - name: httpclient
+    - name: httpserver
       type: capability
       properties:
-        image: wasmcloud.azurecr.io/httpclient:0.5.3
-        contract: wasmcloud:httpclient
+        image: wasmcloud.azurecr.io/httpserver:0.17.0
+        contract: wasmcloud:httpserver
     - name: blobstore
       type: capability
       properties:
         image: wasmcloud.azurecr.io/blobstore_fs:0.2.0
         contract: wasmcloud:blobstore
-    - name: messaging
-      type: capability
-      properties:
-        image: wasmcloud.azurecr.io/nats_messaging:0.16.3
-        contract: wasmcloud:messaging

--- a/actor/echo-messaging/wadm.yaml
+++ b/actor/echo-messaging/wadm.yaml
@@ -1,0 +1,34 @@
+# This is a full example of how to run the echo messaging actor connected to NATS, listening on `wasmcloud.echo`
+# This example requires you to have WADM running: https://github.com/wasmCloud/wadm/tree/main/wadm. You
+# can deploy this example with a simple command:
+#
+# `wash app deploy wadm.yaml`
+
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: echo-messaging
+  annotations:
+    version: v0.0.1
+    description: "wasmCloud Echo Messaging Example"
+spec:
+  components:
+    - name: echo messaging
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/echo_messaging:0.1.7
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1
+        - type: linkdef
+          properties:
+            target: messaging
+            values:
+              SUBSCRIPTION: wasmcloud.echo
+
+    - name: messaging
+      type: capability
+      properties:
+        image: wasmcloud.azurecr.io/nats_messaging:0.16.3
+        contract: wasmcloud:messaging

--- a/actor/hello/wadm.yaml
+++ b/actor/hello/wadm.yaml
@@ -1,4 +1,4 @@
-# This is a full example of how to run the echo actor exposed with an HTTP server. Using this
+# This is a full example of how to run the hello actor exposed with an HTTP server. Using this
 # example requires you to have WADM running: https://github.com/wasmCloud/wadm/tree/main/wadm.
 #
 # To run this example, use: `wash app deploy wadm.yaml`
@@ -6,16 +6,16 @@
 apiVersion: core.oam.dev/v1beta1
 kind: Application
 metadata:
-  name: echo
+  name: hello
   annotations:
     version: v0.0.1
-    description: "wasmCloud Echo Example"
+    description: "wasmCloud Hello World Example"
 spec:
   components:
-    - name: echo
+    - name: hello
       type: actor
       properties:
-        image: wasmcloud.azurecr.io/echo:0.3.5
+        image: wasmcloud.azurecr.io/hello:0.1.7
       traits:
         - type: spreadscaler
           properties:

--- a/actor/kvcounter/wadm.yaml
+++ b/actor/kvcounter/wadm.yaml
@@ -37,10 +37,10 @@ spec:
     - name: httpserver
       type: capability
       properties:
-        image: wasmcloud.azurecr.io/httpserver:0.16.2
+        image: wasmcloud.azurecr.io/httpserver:0.17.0
         contract: wasmcloud:httpserver
     - name: redis
       type: capability
       properties:
-        image: wasmcloud.azurecr.io/kvredis:0.16.3
+        image: wasmcloud.azurecr.io/kvredis:0.19.0
         contract: wasmcloud:keyvalue

--- a/actor/message-pub/README.md
+++ b/actor/message-pub/README.md
@@ -3,15 +3,18 @@
 This actor receives HTTP requests and publishes the request body on a topic without waiting for a reply. This can be used to transform messages sent over HTTP to a message broker pub (if no reply is needed) and also serves as an example for how you can send messages using the messaging capability.
 
 ## Required Capability Claims
+
 1. `wasmcloud:httpserver` to receive HTTP requests
 1. `wasmcloud:messaging` to send a message on a message broker
 
 ## Running this actor
+
 Start a wasmCloud host as detailed in the [Installation Guide](https://wasmcloud.dev/overview/installation/), build your actor using `make`, then start your actor using the `From File` option in the wasmCloud dashboard. The wasmCloud [HTTP Server](https://github.com/wasmCloud/capability-providers/tree/main/httpserver-rs) and [NATS messaging](https://github.com/wasmCloud/capability-providers/tree/main/nats) providers are first-party resources that fulfill the above contracts, but you're free to use your own as well. Simply start those providers and link them to your actor, giving the HTTP server link value something like `address=0.0.0.0:8080`, then you can use the [NATS CLI](https://github.com/nats-io/natscli) to listen for messages while making requests to `localhost:8080`.
 
 Once you've installed **wash** and ran wasmCloud after following the [installation guide](https://wasmcloud.dev/overview/installation/), you can run this example actor and the wasmCloud providers with the following commands:
+
 ```
-wash ctl start actor wasmcloud.azurecr.io/message-pub:0.1.0
+wash ctl start actor wasmcloud.azurecr.io/message-pub:0.1.3
 # If you use a locally build actor, replace the actor ID below with your own
 wash ctl link put MC3QONHYH3FY4KYFCOSVJWIDJG4WA2PVD6FHKR7FFT457GVUTZJYR2TJ VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M wasmcloud:httpserver address=0.0.0.0:8080
 wash ctl link put MC3QONHYH3FY4KYFCOSVJWIDJG4WA2PVD6FHKR7FFT457GVUTZJYR2TJ VADNMSIML2XGO2X4TPIONTIC55R2UUQGPPDZPAVSC2QD7E76CR77SPW7 wasmcloud:messaging
@@ -20,6 +23,7 @@ wash ctl start provider wasmcloud.azurecr.io/nats_messaging:0.14.5 --skip-wait
 ```
 
 And you can subscribe for messages with:
+
 ```
 nats sub "wasmcloud.http.>"
 ```

--- a/actor/message-pub/wadm.yaml
+++ b/actor/message-pub/wadm.yaml
@@ -35,7 +35,7 @@ spec:
     - name: httpserver
       type: capability
       properties:
-        image: wasmcloud.azurecr.io/httpserver:0.16.2
+        image: wasmcloud.azurecr.io/httpserver:0.17.0
         contract: wasmcloud:httpserver
     - name: messaging
       type: capability

--- a/actor/message-pub/wadm.yaml
+++ b/actor/message-pub/wadm.yaml
@@ -9,38 +9,36 @@
 apiVersion: core.oam.dev/v1beta1
 kind: Application
 metadata:
-  name: kvcounter
+  name: message-pub
   annotations:
     version: v0.0.1
-    description: "wasmCloud Key Value Counter Example"
+    description: "wasmCloud Message Pub Example"
 spec:
   components:
-    - name: kvcounter
+    - name: messagepub
       type: actor
       properties:
-        image: wasmcloud.azurecr.io/kvcounter:0.4.0
+        image: wasmcloud.azurecr.io/message-pub:0.1.3
       traits:
         - type: spreadscaler
           properties:
             replicas: 1
         - type: linkdef
           properties:
-            target: redis
-            values:
-              URL: redis://127.0.0.1:6379/
+            target: messaging
         - type: linkdef
           properties:
             target: httpserver
             values:
-              ADDRESS: 0.0.0.0:8081
+              ADDRESS: 0.0.0.0:8080
 
     - name: httpserver
       type: capability
       properties:
         image: wasmcloud.azurecr.io/httpserver:0.16.2
         contract: wasmcloud:httpserver
-    - name: redis
+    - name: messaging
       type: capability
       properties:
-        image: wasmcloud.azurecr.io/kvredis:0.16.3
-        contract: wasmcloud:keyvalue
+        image: wasmcloud.azurecr.io/nats_messaging:0.16.3
+        contract: wasmcloud:messaging

--- a/actor/policy/wadm.yaml
+++ b/actor/policy/wadm.yaml
@@ -1,0 +1,54 @@
+# This is the full manifest for running a the example policy actor on a host _without_ policy enabled,
+# in order to enforce the policy of the rest of the lattice.
+# To run the policy host, start it with `HOST_policy=enforcer wash up`
+# Then to run additional hosts, start them with the env var `WASMCLOUD_POLICY_SERVER=wasmcloud.policy.evaluator` set
+#
+# This requires you to have https://github.com/wasmCloud/wadm/tree/main/wadm running.
+
+# You can deploy this example with a simple command:
+#
+# `wash app deploy wadm.yaml`
+
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: policy
+  annotations:
+    version: v0.0.1
+    description: "wasmCloud Policy Example"
+spec:
+  components:
+    - name: policy
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/example_policy:0.1.3
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1
+            spread:
+              # Policy actor must run on a host without policy enabled
+              - name: policy-host
+                requirements:
+                  policy: enforcer
+
+        - type: linkdef
+          properties:
+            target: messaging
+            values:
+              SUBSCRIPTION: wasmcloud.policy.evaluator
+
+    - name: messaging
+      type: capability
+      properties:
+        image: wasmcloud.azurecr.io/nats_messaging:0.16.3
+        contract: wasmcloud:messaging
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1
+            spread:
+              # Messaging provider must run on a host without policy enabled
+              - name: policy-host
+                requirements:
+                  host: policy

--- a/actor/random/wadm.yaml
+++ b/actor/random/wadm.yaml
@@ -1,0 +1,23 @@
+# This example runs the random actor which can be interacted with via `wash call`.
+# This requires you to have https://github.com/wasmCloud/wadm/tree/main/wadm running.
+# You can deploy this example with a simple command:
+#
+# `wash app deploy wadm.yaml`
+
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: random
+  annotations:
+    version: v0.0.1
+    description: "wasmCloud Random Example"
+spec:
+  components:
+    - name: random
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/example_random:0.1.6
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1

--- a/actor/todo/wadm.yaml
+++ b/actor/todo/wadm.yaml
@@ -1,4 +1,4 @@
-# This is a full example of how to run the kvcounter actor exposed with an HTTP server. Using this
+# This is a full example of how to run the todo actor exposed with an HTTP server. Using this
 # example requires you to have a Redis server running locally (though the linkdef can be modified to
 # use a Redis server you have running elsewhere) and WADM running:
 #
@@ -9,16 +9,16 @@
 apiVersion: core.oam.dev/v1beta1
 kind: Application
 metadata:
-  name: kvcounter
+  name: todo
   annotations:
     version: v0.0.1
-    description: "wasmCloud Key Value Counter Example"
+    description: "wasmCloud TODO API Example"
 spec:
   components:
-    - name: kvcounter
+    - name: todo
       type: actor
       properties:
-        image: wasmcloud.azurecr.io/kvcounter:0.4.0
+        image: wasmcloud.azurecr.io/todo:0.3.8
       traits:
         - type: spreadscaler
           properties:
@@ -32,7 +32,7 @@ spec:
           properties:
             target: httpserver
             values:
-              ADDRESS: 0.0.0.0:8081
+              ADDRESS: 0.0.0.0:8080
 
     - name: httpserver
       type: capability

--- a/actor/todo/wadm.yaml
+++ b/actor/todo/wadm.yaml
@@ -37,10 +37,10 @@ spec:
     - name: httpserver
       type: capability
       properties:
-        image: wasmcloud.azurecr.io/httpserver:0.16.2
+        image: wasmcloud.azurecr.io/httpserver:0.17.0
         contract: wasmcloud:httpserver
     - name: redis
       type: capability
       properties:
-        image: wasmcloud.azurecr.io/kvredis:0.16.3
+        image: wasmcloud.azurecr.io/kvredis:0.19.0
         contract: wasmcloud:keyvalue

--- a/actor/xkcd/wadm.yaml
+++ b/actor/xkcd/wadm.yaml
@@ -1,4 +1,4 @@
-# This is a full example of how to run the echo actor exposed with an HTTP server. Using this
+# This is a full example of how to run the xkcd actor exposed with an HTTP server. Using this
 # example requires you to have WADM running: https://github.com/wasmCloud/wadm/tree/main/wadm.
 #
 # To run this example, use: `wash app deploy wadm.yaml`
@@ -6,16 +6,16 @@
 apiVersion: core.oam.dev/v1beta1
 kind: Application
 metadata:
-  name: echo
+  name: xkcd
   annotations:
     version: v0.0.1
-    description: "wasmCloud Echo Example"
+    description: "wasmCloud XKCD Example"
 spec:
   components:
-    - name: echo
+    - name: xkcd
       type: actor
       properties:
-        image: wasmcloud.azurecr.io/echo:0.3.5
+        image: wasmcloud.azurecr.io/xkcd:0.1.7
       traits:
         - type: spreadscaler
           properties:
@@ -25,9 +25,17 @@ spec:
             target: httpserver
             values:
               ADDRESS: 127.0.0.1:8080
+        - type: linkdef
+          properties:
+            target: httpclient
 
     - name: httpserver
       type: capability
       properties:
         image: wasmcloud.azurecr.io/httpserver:0.17.0
         contract: wasmcloud:httpserver
+    - name: httpclient
+      type: capability
+      properties:
+        image: wasmcloud.azurecr.io/httpclient:0.6.0
+        contract: wasmcloud:httpclient

--- a/petclinic/wadm.yaml
+++ b/petclinic/wadm.yaml
@@ -1,9 +1,9 @@
-# This is a full example of how to run the petclinic example. Using this example requires you to
-# have WADM running: https://github.com/wasmCloud/wadm/tree/main/wadm and a host labeled with
-# `app=petclinic`. You can deploy this example with two simple commands:
+# This is a full manifest of the petclinic example. Using this example requires you to
+# have WADM running: https://github.com/wasmCloud/wadm.
 #
-# `wash app put wadm.yaml`
-# `wash app deploy petclinic 0.0.1`
+# Please note that the connection URI in this manifest is insecure for ease-of-use, and
+# should not be used in a production scenario.
+# You can deploy this example with a simple command: `wash app deploy wadm.yaml`
 
 apiVersion: core.oam.dev/v1beta1
 kind: Application
@@ -22,65 +22,48 @@ spec:
         - type: spreadscaler
           properties:
             replicas: 1
-            spread:
-              - name: uiclinicapp
-                requirements:
-                  app: petclinic
 
     - name: customers
       type: actor
       properties:
         image: wasmcloud.azurecr.io/customers:0.3.1
       traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1
         - type: linkdef
           properties:
             target: postgres
             values:
-              uri: postgres://user:pass@your.db.host.com/petclinic
-        - type: spreadscaler
-          properties:
-            replicas: 1
-            spread:
-              - name: customersclinicapp
-                requirements:
-                  app: petclinic
+              uri: postgres://petclinic:supersecret123@127.0.0.1:5432/petclinic
 
     - name: vets
       type: actor
       properties:
         image: wasmcloud.azurecr.io/vets:0.3.1
       traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1
         - type: linkdef
           properties:
             target: postgres
             values:
-              uri: postgres://user:pass@your.db.host.com/petclinic
-        - type: spreadscaler
-          properties:
-            replicas: 1
-            spread:
-              - name: vetsclinicapp
-                requirements:
-                  app: petclinic
+              uri: postgres://petclinic:supersecret123@127.0.0.1:5432/petclinic
 
     - name: visits
       type: actor
       properties:
         image: wasmcloud.azurecr.io/visits:0.3.1
       traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1
         - type: linkdef
           properties:
             target: postgres
             values:
-              uri: postgres://user:pass@your.db.host.com/petclinic
-
-        - type: spreadscaler
-          properties:
-            replicas: 1
-            spread:
-              - name: visitsclinicapp
-                requirements:
-                  app: petclinic
+              uri: postgres://petclinic:supersecret123@127.0.0.1:5432/petclinic
 
     - name: clinicapi
       type: actor
@@ -90,10 +73,6 @@ spec:
         - type: spreadscaler
           properties:
             replicas: 1
-            spread:
-              - name: clinicapp
-                requirements:
-                  app: petclinic
         - type: linkdef
           properties:
             target: httpserver
@@ -103,27 +82,10 @@ spec:
     - name: httpserver
       type: capability
       properties:
-        image: wasmcloud.azurecr.io/httpserver:0.16.2
+        image: wasmcloud.azurecr.io/httpserver:0.16.3
         contract: wasmcloud:httpserver
-      traits:
-        - type: spreadscaler
-          properties:
-            replicas: 1
-            spread:
-              - name: httpserverspread
-                requirements:
-                  app: petclinic
-
     - name: postgres
       type: capability
       properties:
-        image: wasmcloud.azurecr.io/sqldb-postgres:0.3.1
+        image: wasmcloud.azurecr.io/sqldb-postgres:0.3.4
         contract: wasmcloud:sqldb
-      traits:
-        - type: spreadscaler
-          properties:
-            replicas: 1
-            spread:
-              - name: postgresspread
-                requirements:
-                  app: petclinic


### PR DESCRIPTION
## Feature or Problem
This PR adds `wadm.yaml` manifests for each example so that you can use wadm to easily run them. This PR is purely meant to be additive, doesn't add manifests for actors that are not published to an OCI repo, and doesn't update the README quite yet as wadm is still in alpha state.

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
N/A

### Acceptance or Integration
N/A

### Manual Verification
I ran each manifest to make sure wadm could start the resources 😄 