### PR TITLE
Add JSON and CORS headers to requests

### DIFF
--- a/leaderboard/src/lib.rs
+++ b/leaderboard/src/lib.rs
@@ -25,25 +25,19 @@ impl HttpServer for LeaderboardActor {
                 post_score(ctx, leaderboard_id, deser_json(&req.body)?).await
             }
             (_, _) => Ok(HttpResponse::not_found()),
-        };
+        }?;
 
-        result
-            .as_mut()
-            .map(|res| {
-                res.header.extend([
-                    (
-                        "Access-Control-Allow-Origin".to_owned(),
-                        vec!["*".to_owned()],
-                    ),
-                    (
-                        "Content-Type".to_owned(),
-                        vec!["application/json".to_owned()],
-                    ),
-                ]);
-            })
-            .unwrap_or_default();
-
-        result
+        result.header.extend([
+            (
+                "Access-Control-Allow-Origin".to_owned(),
+                vec!["*".to_owned()],
+            ),
+            (
+                "Content-Type".to_owned(),
+                vec!["application/json".to_owned()],
+            ),
+        ]);
+        Ok(result)
     }
 }
 

--- a/leaderboard/src/lib.rs
+++ b/leaderboard/src/lib.rs
@@ -17,7 +17,7 @@ impl HttpServer for LeaderboardActor {
         let path = &req.path[1..req.path.len()];
         let segments: Vec<&str> = path.trim_end_matches('/').split('/').collect();
 
-        match (req.method.as_ref(), segments.as_slice()) {
+        let mut result = match (req.method.as_ref(), segments.as_slice()) {
             ("GET", ["leaderboards"]) => get_leaderboards(ctx).await,
             ("POST", ["leaderboards"]) => create_leaderboard(ctx, deser_json(&req.body)?).await,
             ("GET", ["leaderboards", leaderboard_id]) => get_leaderboard(ctx, leaderboard_id).await,
@@ -25,7 +25,25 @@ impl HttpServer for LeaderboardActor {
                 post_score(ctx, leaderboard_id, deser_json(&req.body)?).await
             }
             (_, _) => Ok(HttpResponse::not_found()),
-        }
+        };
+
+        result
+            .as_mut()
+            .map(|res| {
+                res.header.extend([
+                    (
+                        "Access-Control-Allow-Origin".to_owned(),
+                        vec!["*".to_owned()],
+                    ),
+                    (
+                        "Content-Type".to_owned(),
+                        vec!["application/json".to_owned()],
+                    ),
+                ]);
+            })
+            .unwrap_or_default();
+
+        result
     }
 }
 


### PR DESCRIPTION
## Feature or Problem
This API is made to demonstrate interactivity with a web client (amongst others) so we need a CORS header. The JSON header is purely optional, but it helps with apps like Postman.

## Related Issues
None

## Release Information
`next`

## Consumer Impact
Consumers of the API can now use web browser clients

## Testing
Works on my machine

Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows