### PR TITLE
Removed make in favor of wash build

### DIFF
--- a/.github/workflows/pinger.yml
+++ b/.github/workflows/pinger.yml
@@ -45,7 +45,7 @@ jobs:
         run: rustup target add wasm32-unknown-unknown
 
       - name: Build wasmcloud actor
-        run: make
+        run: wash build
         working-directory: ${{ env.working-directory }}
       
       - name: Upload signed actor to GH Actions

--- a/.github/workflows/ponger.yml
+++ b/.github/workflows/ponger.yml
@@ -45,7 +45,7 @@ jobs:
         run: rustup target add wasm32-unknown-unknown
 
       - name: Build wasmcloud actor
-        run: make
+        run: wash build
         working-directory: ${{ env.working-directory }}
       
       - name: Upload signed actor to GH Actions


### PR DESCRIPTION
This PR removes the `make` from the pinger/ponger actions in favor of wash build