### PR TITLE
ref(blobby): Refactors blobby tests

### DIFF
--- a/actor/blobby/README.md
+++ b/actor/blobby/README.md
@@ -27,12 +27,12 @@ guide](https://wasmcloud.dev/overview/installation/), you can run this example a
 wasmCloud providers with the following commands:
 
 ```
-$ wash ctl start actor wasmcloud.azurecr.io/blobby:0.2.0
+$ wash ctl start actor wasmcloud.azurecr.io/blobby:0.2.1
 # If you use a locally built actor, replace the actor ID below with your own
 $ wash ctl link put MBY3COMRDLQYTX2AUTNB5D2WYAH5TUKNIMELDSQ5BUFZVV7CBUUIKEDR VBBQNNCGUKIXEWLL5HL5XJE57BS3GU5DMDOKZS6ROEWPQFHEDP6NGVZM wasmcloud:blobstore "ROOT=/tmp"
 $ wash ctl link put MBY3COMRDLQYTX2AUTNB5D2WYAH5TUKNIMELDSQ5BUFZVV7CBUUIKEDR VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M wasmcloud:httpserver "ADDRESS=0.0.0.0:8080"
-$ wash ctl start provider wasmcloud.azurecr.io/blobstore_fs:0.3.1 --skip-wait
-$ wash ctl start provider wasmcloud.azurecr.io/httpserver:0.17.0 --skip-wait
+$ wash ctl start provider wasmcloud.azurecr.io/blobstore_fs:0.3.2 --skip-wait
+$ wash ctl start provider wasmcloud.azurecr.io/httpserver:0.18.2 --skip-wait
 ```
 
 Once everything is up and running, you can run through all of the operations by following the
@@ -169,16 +169,14 @@ $ wash build
 
 ### Testing the actor
 
-Testing the actor is just a bit more complex, but still fairly easy
+Testing the actor is also easy:
 
 ```console
 $ cd testing
-$ cargo test -- --test-threads 1
+$ cargo test
 ```
 
-This will automatically build your actor and then run the tests. The `--test-threads 1` only runs
-one test at a time as a workaround until we can put in the work to automatically generate different
-ports for everything that is starting up
+This will automatically build your actor and then run the tests.
 
 Please note that these tests are currently being used as a testbed for actor integration testing. It
 is likely we will try to wrap this up in some sort of testing tool in the future!

--- a/actor/blobby/actor/Cargo.lock
+++ b/actor/blobby/actor/Cargo.lock
@@ -29,9 +29,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
@@ -65,21 +65,22 @@ checksum = "ca6c635b3aa665c649ad1415f1573c85957dfa47690ec27aebe7ec17efe3c643"
 
 [[package]]
 name = "async-nats"
-version = "0.23.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9323e13cccc5d28a249e3d0c22600129703c75283a73fc3ebb3dbd2d51bef1cb"
+checksum = "1174495e436c928905018f10a36160f7a8a6786450f50f4ce7fba05d1539704c"
 dependencies = [
- "base64",
+ "async-nats-tokio-rustls-deps",
+ "base64 0.13.0",
  "base64-url",
  "bytes",
  "futures",
  "http",
- "itertools",
  "itoa",
- "lazy_static",
+ "memchr",
  "nkeys",
  "nuid",
  "once_cell",
+ "rand",
  "regex",
  "ring",
  "rustls-native-certs",
@@ -88,13 +89,23 @@ dependencies = [
  "serde_json",
  "serde_nanos",
  "serde_repr",
- "subslice",
+ "thiserror",
  "time",
  "tokio",
  "tokio-retry",
- "tokio-rustls",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "async-nats-tokio-rustls-deps"
+version = "0.24.0-ALPHA.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cdefe54cd7867d937c0a507d2a3a830af410044282cd3e4002b5b7860e1892e"
+dependencies = [
+ "rustls 0.21.2",
+ "tokio",
+ "webpki",
 ]
 
 [[package]]
@@ -105,7 +116,7 @@ checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.101",
 ]
 
 [[package]]
@@ -207,12 +218,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "base64"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+
+[[package]]
 name = "base64-url"
 version = "1.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67a99c239d0c7e77c85dddfa9cebce48704b3c49550fcd3b84dd637e4484899f"
 dependencies = [
- "base64",
+ "base64 0.13.0",
 ]
 
 [[package]]
@@ -229,7 +246,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "blobby"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "form_urlencoded",
  "futures",
@@ -275,9 +292,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cc"
@@ -293,47 +310,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.2.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
-dependencies = [
- "atty",
- "bitflags",
- "clap_derive 3.2.18",
- "clap_lex 0.2.4",
- "indexmap",
- "once_cell",
- "strsim",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap"
 version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec7a4128863c188deefe750ac1d1dfe66c236909f845af04beed823638dc1b2"
 dependencies = [
  "bitflags",
- "clap_derive 4.1.0",
- "clap_lex 0.3.1",
+ "clap_derive",
+ "clap_lex",
  "is-terminal",
  "once_cell",
  "strsim",
  "termcolor",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
-dependencies = [
- "heck 0.4.0",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -346,16 +333,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
+ "syn 1.0.101",
 ]
 
 [[package]]
@@ -415,7 +393,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdffe87e1d521a10f9696f833fe502293ea446d7f256c06128293a4119bdf4cb"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.101",
 ]
 
 [[package]]
@@ -526,12 +504,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -631,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -641,15 +613,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -658,38 +630,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-util"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -804,9 +776,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
@@ -874,7 +846,7 @@ checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
 dependencies = [
  "http",
  "hyper",
- "rustls",
+ "rustls 0.20.6",
  "tokio",
  "tokio-rustls",
 ]
@@ -937,15 +909,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -977,9 +940,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.134"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1125,9 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "opaque-debug"
@@ -1248,7 +1211,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.101",
 ]
 
 [[package]]
@@ -1279,7 +1242,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.101",
 ]
 
 [[package]]
@@ -1333,7 +1296,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.101",
  "version_check",
 ]
 
@@ -1350,18 +1313,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.46"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -1424,13 +1387,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.2",
 ]
 
 [[package]]
@@ -1439,7 +1402,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax",
+ "regex-syntax 0.6.27",
 ]
 
 [[package]]
@@ -1447,6 +1410,12 @@ name = "regex-syntax"
 version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "remove_dir_all"
@@ -1463,7 +1432,7 @@ version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1480,7 +1449,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.20.6",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -1572,6 +1541,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e32ca28af694bc1bbf399c33a516dbdf1c90090b8ab23c2bc24f834aa2247f5f"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
 name = "rustls-native-certs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1585,11 +1566,21 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64",
+ "base64 0.21.2",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -1655,9 +1646,9 @@ checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
-version = "1.0.145"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
@@ -1673,20 +1664,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.145"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a"
 dependencies = [
  "itoa",
  "ryu",
@@ -1695,22 +1686,31 @@ dependencies = [
 
 [[package]]
 name = "serde_nanos"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44969a61f5d316be20a42ff97816efb3b407a924d06824c3d8a49fa8450de0e"
+checksum = "8ae801b7733ca8d6a2b580debe99f67f36826a0f5b8a36055dc6bc40f8d6bc71"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_repr"
-version = "0.1.9"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
+checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1813,9 +1813,9 @@ checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
@@ -1843,15 +1843,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "subslice"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a8e4809a3bb02de01f1f7faf1ba01a83af9e8eabcd4d31dd6e413d14d56aae"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1869,6 +1860,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1876,7 +1878,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.101",
  "unicode-xid",
 ]
 
@@ -1904,12 +1906,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
-
-[[package]]
 name = "thiserror"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1926,7 +1922,7 @@ checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.101",
 ]
 
 [[package]]
@@ -1940,9 +1936,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
 dependencies = [
  "itoa",
  "serde",
@@ -1952,15 +1948,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
 dependencies = [
  "time-core",
 ]
@@ -1982,14 +1978,13 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.2"
+version = "1.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "parking_lot",
@@ -1997,18 +1992,18 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2028,7 +2023,7 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls",
+ "rustls 0.20.6",
  "tokio",
  "webpki",
 ]
@@ -2054,6 +2049,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -2083,7 +2112,7 @@ checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.101",
 ]
 
 [[package]]
@@ -2254,7 +2283,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32d1cfad67501627ac9344cbd89be80d2d5ebc98ef3b86862041cb26a280081f"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "data-encoding",
  "env_logger",
  "humantime",
@@ -2296,7 +2325,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -2330,7 +2359,7 @@ checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2350,19 +2379,19 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.101",
 ]
 
 [[package]]
 name = "wasmbus-rpc"
-version = "0.11.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40741670f20464a709dda3a7b036cd84fc1210f8399fb85e6bf7f56893654c4c"
+checksum = "2ba72e61b8361650149b2650b72c583a1d50ac78f75213b74eaec049699c5d93"
 dependencies = [
  "async-nats",
  "async-trait",
  "atty",
- "base64",
+ "base64 0.13.0",
  "bytes",
  "cfg-if",
  "data-encoding",
@@ -2380,21 +2409,21 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
- "toml",
+ "toml 0.5.9",
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
  "uuid",
  "wascap",
  "wasmbus-macros",
- "weld-codegen 0.6.0",
+ "weld-codegen",
 ]
 
 [[package]]
 name = "wasmcloud-interface-blobstore"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4da8efd0df93cc4adcb0778e5561ba921ba530d328a39d955a329d2bdd67179e"
+checksum = "f1d3821b7f495ffc52f4072de3ee35294138f4832ecfe5a542c2071eb87a1d3b"
 dependencies = [
  "async-trait",
  "futures",
@@ -2402,28 +2431,28 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "wasmbus-rpc",
- "weld-codegen 0.5.0",
+ "weld-codegen",
 ]
 
 [[package]]
 name = "wasmcloud-interface-httpserver"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea02a20445b828ee195737fb3e23725d8a7356afa67cf2b8b58d74b7c44e43b"
+checksum = "ab9d96cd17d32dd3d3fb14f05a69ce4ac62c52d13c68903d2dc8cefd2d906bce"
 dependencies = [
  "async-trait",
  "serde",
  "serde_bytes",
  "serde_json",
  "wasmbus-rpc",
- "weld-codegen 0.5.0",
+ "weld-codegen",
 ]
 
 [[package]]
 name = "wasmcloud-interface-logging"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "689624eff781235ce90f6e68fe6c099643b10c8a66959848581f30959866d43c"
+checksum = "a0db7ac53cdf45794b9c0a8ee1a62b44797c794823c106eda1b2f9bdc3b2c147"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -2432,7 +2461,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "wasmbus-rpc",
- "weld-codegen 0.5.0",
+ "weld-codegen",
 ]
 
 [[package]]
@@ -2466,9 +2495,9 @@ dependencies = [
 
 [[package]]
 name = "weld-codegen"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a116c5da028abf02e952882a998e5aef9dabca49a86569c39904fe341386546"
+checksum = "66385fd8affabb09b678d2f826c78d995789cdb2fbb2dd02e6010dffe298797e"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -2478,7 +2507,7 @@ dependencies = [
  "atelier_smithy",
  "bytes",
  "cfg-if",
- "clap 3.2.22",
+ "clap",
  "directories",
  "downloader",
  "handlebars",
@@ -2491,37 +2520,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
- "toml",
-]
-
-[[package]]
-name = "weld-codegen"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0897960d6e7c55863b78d5bb48858c7f243a731c416f12cc47854b74ca1a85"
-dependencies = [
- "Inflector",
- "anyhow",
- "atelier_assembler",
- "atelier_core",
- "atelier_json",
- "atelier_smithy",
- "bytes",
- "cfg-if",
- "clap 4.1.1",
- "directories",
- "downloader",
- "handlebars",
- "lazy_static",
- "lexical-sort",
- "reqwest",
- "rustc-hash",
- "semver",
- "serde",
- "serde_json",
- "tempfile",
- "thiserror",
- "toml",
+ "toml 0.7.4",
 ]
 
 [[package]]
@@ -2574,13 +2573,37 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
+ "windows_aarch64_gnullvm 0.42.1",
  "windows_aarch64_msvc 0.42.1",
  "windows_i686_gnu 0.42.1",
  "windows_i686_msvc 0.42.1",
  "windows_x86_64_gnu 0.42.1",
- "windows_x86_64_gnullvm",
+ "windows_x86_64_gnullvm 0.42.1",
  "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -2588,6 +2611,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2602,6 +2631,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2612,6 +2647,12 @@ name = "windows_i686_gnu"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2626,6 +2667,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2638,10 +2685,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2654,6 +2713,21 @@ name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"
@@ -2681,6 +2755,6 @@ checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.101",
  "synstructure",
 ]

--- a/actor/blobby/testing/Cargo.lock
+++ b/actor/blobby/testing/Cargo.lock
@@ -26,6 +26,7 @@ version = "0.1.0"
 dependencies = [
  "reqwest",
  "serde_json",
+ "tempfile",
  "tokio",
 ]
 

--- a/actor/blobby/testing/Cargo.toml
+++ b/actor/blobby/testing/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 serde_json = "1.0.85"
 tokio = { version = "1", features = ["full"] }
 reqwest = "0.11"
+tempfile = "3"

--- a/actor/blobby/testing/tests/setup.rs
+++ b/actor/blobby/testing/tests/setup.rs
@@ -1,148 +1,252 @@
-use tokio::process::Command;
+use std::net::{Ipv4Addr, SocketAddrV4};
+use std::path::PathBuf;
+
+use tempfile::TempDir;
+use tokio::net::TcpListener;
+use tokio::process::{Child, Command};
 
 const HTTP_SERVER_PROVIDER_ID: &str = "VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M";
 const BLOBSTORE_PROVIDER_ID: &str = "VBBQNNCGUKIXEWLL5HL5XJE57BS3GU5DMDOKZS6ROEWPQFHEDP6NGVZM";
-const DOCKER_REGISTRY_NAME: &str = "blobby-test";
-const REGISTRY_REF: &str = "localhost:9999/blobby:dev";
-const BLOBBY_PATH: &str = "../actor/build/blobby_s.wasm";
-const WASHBOARD_URL: &str = "localhost:4000";
-const SERVER_URL: &str = "127.0.0.1:8080";
+const DEFAULT_WASMCLOUD_PORT: u16 = 4000;
+const DEFAULT_NATS_PORT: u16 = 4222;
 
+// NOTE: this wash setup code is wholesale copied from wadm. We should probably put this in a library
+
+/// Get a TCP random port
+async fn get_random_tcp_port() -> u16 {
+    TcpListener::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("Unable to bind to check for port")
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+#[derive(Debug)]
 pub struct CleanupGuard {
-    already_running: bool,
+    child: Option<Child>,
+    _log_dir: TempDir,
+    stdout_file: PathBuf,
+    stderr_file: PathBuf,
 }
 
 impl Drop for CleanupGuard {
     fn drop(&mut self) {
-        match std::process::Command::new("docker")
-            .args(["rm", "-f", DOCKER_REGISTRY_NAME])
-            .output()
-        {
-            Ok(o) if !o.status.success() => {
-                eprintln!(
-                    "Error stopping docker container: {}",
-                    String::from_utf8_lossy(&o.stderr)
-                )
-            }
-            Err(e) => eprintln!("Error stopping docker container: {}", e),
-            _ => (),
+        if let Some(mut child) = self.child.take() {
+            let _ = child.start_kill();
         }
+    }
+}
 
-        if !self.already_running {
-            match std::process::Command::new("wash").args(["down"]).output() {
-                Ok(o) if !o.status.success() => {
-                    eprintln!(
-                        "Error stopping wasmcloud host: {}",
-                        String::from_utf8_lossy(&o.stderr)
-                    )
-                }
-                Err(e) => eprintln!("Error stopping wasmcloud host: {}", e),
-                _ => (),
+impl CleanupGuard {
+    /// Reads all of stdout from the child process and returns it
+    async fn stdout(&self) -> Vec<u8> {
+        tokio::fs::read(&self.stdout_file)
+            .await
+            .expect("Unable to read stdout")
+    }
+
+    /// Reads all of stderr from the child process and returns it
+    #[allow(dead_code)]
+    async fn stderr(&self) -> Vec<u8> {
+        tokio::fs::read(&self.stderr_file)
+            .await
+            .expect("Unable to read stderr")
+    }
+}
+
+/// Configuration struct for wash instances that are used for testing
+#[derive(Debug, Default)]
+struct TestWashConfig {
+    /// Port on which to run wasmCloud
+    nats_port: Option<u16>,
+
+    /// Only connect to pre-existing NATS instance
+    nats_connect_only: bool,
+
+    /// Port on which to run wasmCloud (via `wash up`)
+    wasmcloud_port: Option<u16>,
+}
+
+impl TestWashConfig {
+    /// Build a test wash configuration with randomized ports
+    async fn random() -> TestWashConfig {
+        let nats_port = Some(get_random_tcp_port().await);
+        let wasmcloud_port = Some(get_random_tcp_port().await);
+
+        TestWashConfig {
+            nats_port,
+            wasmcloud_port,
+            ..TestWashConfig::default()
+        }
+    }
+
+    /// Get the washboard URL for this config
+    fn washboard_url(&self) -> String {
+        format!(
+            "localhost:{}",
+            self.wasmcloud_port.unwrap_or(DEFAULT_WASMCLOUD_PORT)
+        )
+    }
+}
+
+/// Start a local wash instance
+async fn start_wash_instance(cfg: &TestWashConfig) -> CleanupGuard {
+    let nats_port = cfg.nats_port.unwrap_or(DEFAULT_NATS_PORT).to_string();
+    let wasmcloud_port = cfg
+        .wasmcloud_port
+        .unwrap_or(DEFAULT_WASMCLOUD_PORT)
+        .to_string();
+
+    // Build args
+    let mut args: Vec<&str> = Vec::from(["up", "--nats-port", &nats_port]);
+    if cfg.nats_connect_only {
+        args.push("--nats-connect-only");
+    }
+
+    // NOTE(thomastaylor312): I tried to do this by reading from piped stdin/out but `read_to_end`
+    // didn't work because it was waiting for EOF. I didn't want to waste time writing my own read
+    // that would check when it got pending and then return, so I did this instead
+    let log_dir = tempfile::tempdir().expect("Unable to create tempdir");
+    let stdout_file = log_dir.as_ref().join("stdout");
+    let stderr_file = log_dir.as_ref().join("stderr");
+    let stdout = tokio::fs::File::create(&stdout_file)
+        .await
+        .expect("Unable to create stdout file");
+    let stderr = tokio::fs::File::create(&stderr_file)
+        .await
+        .expect("Unable to create stderr file");
+
+    // Build the command
+    let mut cmd = Command::new("wash");
+    let child = cmd
+        .args(&args)
+        .env("WASMCLOUD_PORT", &wasmcloud_port)
+        .env("WASMCLOUD_DASHBOARD_PORT", &wasmcloud_port)
+        .stderr(stderr.into_std().await)
+        .stdout(stdout.into_std().await)
+        .kill_on_drop(true)
+        .spawn()
+        .expect("Unable to run wash up");
+
+    let guard = CleanupGuard {
+        child: Some(child),
+        _log_dir: log_dir,
+        stdout_file,
+        stderr_file,
+    };
+    // Make sure we can connect to washboard
+    wait_for_server(&cfg.washboard_url(), &guard).await;
+
+    // Give the host just a bit more time to get totally ready
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    guard
+}
+
+/// Set up and run a wash instance that can be used for a test
+async fn setup_test_wash(cfg: &TestWashConfig) -> CleanupGuard {
+    match tokio::net::TcpStream::connect(cfg.washboard_url()).await {
+        Err(_) => start_wash_instance(cfg).await,
+        Ok(_) => CleanupGuard {
+            child: None,
+            _log_dir: tempfile::tempdir().unwrap(),
+            stdout_file: PathBuf::new(),
+            stderr_file: PathBuf::new(),
+        },
+    }
+}
+
+async fn wait_for_server(url: &str, guard: &CleanupGuard) {
+    let mut wait_count = 1;
+    loop {
+        // Magic number: 10 + 1, since we are starting at 1 for humans
+        if wait_count >= 11 {
+            let out = guard.stdout().await;
+            let stdout = String::from_utf8_lossy(&out);
+            let err = guard.stderr().await;
+            let stderr = String::from_utf8_lossy(&err);
+            panic!("Ran out of retries waiting for host to start. Server logs:\nStdout:\n{stdout}\nStderr:\n{stderr}");
+        }
+        match tokio::net::TcpStream::connect(url).await {
+            Ok(_) => break,
+            Err(e) => {
+                eprintln!("Waiting for server {url} to come up, attempt {wait_count}. Will retry in 1 second. Got error {e:?}");
+                wait_count += 1;
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
             }
         }
     }
+}
+
+/// Runs wash with the given args and makes sure it runs successfully. Returns the contents of
+/// stdout
+pub async fn run_wash_command<I, S>(args: I) -> Vec<u8>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<std::ffi::OsStr>,
+{
+    let output = Command::new("wash")
+        .args(args)
+        .output()
+        .await
+        .expect("Unable to run wash command");
+    if !output.status.success() {
+        panic!(
+            "wash command didn't exit successfully: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    }
+    output.stdout
 }
 
 // TODO: Make this actually be unique for each test so we can run in parallel
 pub async fn setup_test() -> (String, CleanupGuard) {
     // Build module
     let output = Command::new("wash")
-        .arg("build")
+        .args(["build", "-o", "json"])
         .current_dir("../actor")
-        .status()
-        .await
-        .expect("Unable to run wash build");
-    assert!(output.success(), "Error trying to build module",);
-
-    // Get the actor ID
-    let output = Command::new("wash")
-        .args(["claims", "inspect", "-o", "json", BLOBBY_PATH])
         .output()
         .await
-        .expect("Unable to start docker registry");
-    assert!(
-        output.status.success(),
-        "Unable to start docker registry {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
+        .expect("Unable to run wash build");
+    assert!(output.status.success(), "Error trying to build module");
 
-    let claims = serde_json::from_slice::<serde_json::Value>(&output.stdout)
-        .expect("Unable to decode claims");
+    let build_output = serde_json::from_slice::<serde_json::Value>(&output.stdout)
+        .expect("Unable to decode build output");
+
+    let actor_path = build_output
+        .get("actor_path")
+        .and_then(|v| v.as_str())
+        .expect("Couldn't find actor path");
+
+    // Get the actor ID
+    let output = run_wash_command(["claims", "inspect", "-o", "json", actor_path]).await;
+
+    let claims =
+        serde_json::from_slice::<serde_json::Value>(&output).expect("Unable to decode claims");
     let id = claims
         .get("module")
         .and_then(|v| v.as_str())
         .expect("Couldn't find module ID");
 
-    // Temporary step: start docker registry until starting from a file is supported and push to
-    // registry: https://github.com/wasmCloud/wasmcloud-otp/pull/529
-    let _ = Command::new("docker")
-        .args(["rm", "-f", DOCKER_REGISTRY_NAME])
-        .output()
-        .await
-        .expect("Unable to start docker registry");
-    let output = Command::new("docker")
-        .args([
-            "run",
-            "--rm",
-            "-d",
-            "--name",
-            DOCKER_REGISTRY_NAME,
-            "-p",
-            "9999:5000",
-            "registry:2",
-        ])
-        .output()
-        .await
-        .expect("Unable to start docker registry");
-    assert!(
-        output.status.success(),
-        "Unable to start docker registry {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    // If we push to fast, we catch the server with its pants down. Just trying to connect to the
-    // registry in a loop didn't work
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-
-    let output = Command::new("wash")
-        .args(["reg", "push", "--insecure", REGISTRY_REF, BLOBBY_PATH])
-        .output()
-        .await
-        .expect("Unable to push module");
-    assert!(
-        output.status.success(),
-        "Unable to push module {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-
     // NOTE (thomastaylor312): I decided just to use wash to start everything since it does the
     // waiting for me and it mimics what a user would do IRL
 
     // Start wasmcloud host if we don't find one running
-    let already_running = if tokio::net::TcpStream::connect(WASHBOARD_URL).await.is_err() {
-        let output = Command::new("wash")
-            .args(["up", "-d"])
-            .env("WASMCLOUD_OCI_ALLOWED_INSECURE", "localhost:9999")
-            .status()
-            .await
-            .expect("Unable to run wash up");
-        assert!(output.success(), "Error trying to start host",);
-        // Make sure we can connect
-        wait_for_server(WASHBOARD_URL).await;
-        false
-    } else {
-        true
-    };
+    let wash_cfg = TestWashConfig::random().await;
+    let guard = setup_test_wash(&wash_cfg).await;
 
     // TODO: Be idempotent starting providers
 
+    let connection_port = wash_cfg.nats_port.as_ref().unwrap().to_string();
     // Start http server
     let output = Command::new("wash")
         .args([
-            "ctl",
             "start",
             "provider",
-            "wasmcloud.azurecr.io/httpserver:0.17.0",
+            "-p",
+            &connection_port,
+            "wasmcloud.azurecr.io/httpserver:0.18.2",
         ])
         .status()
         .await
@@ -152,10 +256,11 @@ pub async fn setup_test() -> (String, CleanupGuard) {
     // Start blobstore_fs
     let output = Command::new("wash")
         .args([
-            "ctl",
             "start",
             "provider",
-            "wasmcloud.azurecr.io/blobstore_fs:0.3.1",
+            "-p",
+            &connection_port,
+            "wasmcloud.azurecr.io/blobstore_fs:0.3.2",
         ])
         .status()
         .await
@@ -164,7 +269,13 @@ pub async fn setup_test() -> (String, CleanupGuard) {
 
     // Start module
     let output = Command::new("wash")
-        .args(["ctl", "start", "actor", REGISTRY_REF])
+        .args([
+            "start",
+            "actor",
+            "-p",
+            &connection_port,
+            &format!("file://{actor_path}"),
+        ])
         .output()
         .await
         .expect("Unable to start blobby");
@@ -174,16 +285,21 @@ pub async fn setup_test() -> (String, CleanupGuard) {
         String::from_utf8_lossy(&output.stderr)
     );
 
+    // Get a URL to listen on
+    let port = get_random_tcp_port().await;
+    let server_url = format!("127.0.0.1:{}", port);
+
     // Link the things
     let output = Command::new("wash")
         .args([
-            "ctl",
             "link",
             "put",
+            "-p",
+            &connection_port,
             id,
             HTTP_SERVER_PROVIDER_ID,
             "wasmcloud:httpserver",
-            &format!("ADDRESS={}", SERVER_URL),
+            &format!("ADDRESS={}", server_url),
         ])
         .output()
         .await
@@ -196,9 +312,10 @@ pub async fn setup_test() -> (String, CleanupGuard) {
 
     let output = Command::new("wash")
         .args([
-            "ctl",
             "link",
             "put",
+            "-p",
+            &connection_port,
             id,
             BLOBSTORE_PROVIDER_ID,
             "wasmcloud:blobstore",
@@ -214,25 +331,7 @@ pub async fn setup_test() -> (String, CleanupGuard) {
     );
 
     // Make sure the httpserver is ready to test
-    wait_for_server(SERVER_URL).await;
+    wait_for_server(&server_url, &guard).await;
 
-    (SERVER_URL.to_owned(), CleanupGuard { already_running })
-}
-
-async fn wait_for_server(url: &str) {
-    let mut wait_count = 1;
-    loop {
-        // Magic number: 10 + 1, since we are starting at 1 for humans
-        if wait_count >= 11 {
-            panic!("Ran out of retries waiting for host to start");
-        }
-        match tokio::net::TcpStream::connect(url).await {
-            Ok(_) => break,
-            Err(e) => {
-                eprintln!("Waiting for server {} to come up, attempt {}. Will retry in 1 second. Got error {:?}", url, wait_count, e);
-                wait_count += 1;
-                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-            }
-        }
-    }
+    (server_url, guard)
 }


### PR DESCRIPTION
Adds support for running both tests simultaneously and should also solve some of the flakiness. Also removes the need to push to docker and uses the `file://` option instead

Closes #203 