### PR TITLE
fix(kvcounter): Fixes issue with pinned wit-bindgen dep

### DIFF
--- a/actor/kvcounter-wasmcon2023/Cargo.toml
+++ b/actor/kvcounter-wasmcon2023/Cargo.toml
@@ -17,7 +17,7 @@ mime_guess = "2.0.4"
 rust-embed = "6.8.1"
 serde = { version = "1.0.186", features = ["derive"] }
 serde_json = { version = "1.0.105" }
-wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen.git", rev = "749c01697bb3b11daeae4225789e14b765dcf839" }
+wit-bindgen = "0.11"
 
 [build-dependencies]
 anyhow = "1.0.75"

--- a/actor/kvcounter-wasmcon2023/Cargo.toml
+++ b/actor/kvcounter-wasmcon2023/Cargo.toml
@@ -2,13 +2,13 @@
 name = "wasmcon2023-keyvalue"
 version = "0.1.0"
 edition = "2021"
-authors = [ "wasmcloud Team" ]
+authors = ["wasmcloud Team"]
 description = """
 Wasmcon2023 WASI Keyvalue demo
 """
 
 [lib]
-crate-type = [ "cdylib" ]
+crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1.0.75"
@@ -17,7 +17,7 @@ mime_guess = "2.0.4"
 rust-embed = "6.8.1"
 serde = { version = "1.0.186", features = ["derive"] }
 serde_json = { version = "1.0.105" }
-wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen.git", rev = "a15cb9dbee4f619b286fc22879a94f7197d55b18" }
+wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen.git", rev = "749c01697bb3b11daeae4225789e14b765dcf839" }
 
 [build-dependencies]
 anyhow = "1.0.75"

--- a/actor/kvcounter-wasmcon2023/src/lib.rs
+++ b/actor/kvcounter-wasmcon2023/src/lib.rs
@@ -25,7 +25,7 @@ use wasi::{
 mod ui;
 use ui::get_static_asset;
 
-use crate::exports::wasi::http::incoming_handler::{IncomingHandler, IncomingRequest};
+use crate::exports::wasi::http::incoming_handler::{Guest, IncomingRequest};
 
 // NOTE: custom buckets are not yet supported
 const BUCKET: &str = "";
@@ -77,7 +77,7 @@ impl KvCounter {
 }
 
 /// Implementation of the WIT-driven incoming-handler interface for our implementation struct
-impl IncomingHandler for KvCounter {
+impl Guest for KvCounter {
     fn handle(request: IncomingRequest, response: ResponseOutparam) {
         // Decipher method
         let method = incoming_request_method(request);

--- a/actor/kvcounter-wasmcon2023/src/lib.rs
+++ b/actor/kvcounter-wasmcon2023/src/lib.rs
@@ -105,7 +105,7 @@ impl IncomingHandler for KvCounter {
                         response,
                         500,
                         &content_type_json(),
-                        ApiResponse::error("failed to retreive bucket").into_vec(),
+                        ApiResponse::error("failed to retrieve bucket").into_vec(),
                     );
                     return;
                 };
@@ -237,6 +237,7 @@ fn write_http_response(
 
 /// The response that is sent by the API after an operation
 #[derive(Debug, Serialize)]
+#[serde(untagged)]
 pub enum ApiResponse {
     Error { error: String },
     Success { counter: i32 },


### PR DESCRIPTION
For some reason the pinned build we've been using of wit-bindgen started to fail. I updated to a slightly more recent rev which fixes the issue. This also fixed a few small items I found while manually validating that all of this worked