### PR TITLE
fix(a2a): fix wadm for pingerponger

### DIFF
--- a/actor/actor-to-actor/README.md
+++ b/actor/actor-to-actor/README.md
@@ -14,9 +14,6 @@ You'll need [wash](https://wasmcloud.com/docs/installation) installed to run thi
 wash up -d
 wash app deploy ./wadm.yaml
 
-# Invoke the pinger actor's HTTP handler directly
-wash call MBN2KUUZP4Y2F7IRXEPLV232YCZFKGSWYIQ3DNPDIERBE4BHPMUC5BUX HttpServer.HandleRequest '{"method": "GET", "path": "/", "body": "", "queryString":"","header":{}}'
-
 # cURL the pinger's HTTP handler
 curl localhost:8080
 ```

--- a/actor/actor-to-actor/wadm.yaml
+++ b/actor/actor-to-actor/wadm.yaml
@@ -17,7 +17,9 @@ spec:
             replicas: 1
         - type: linkdef
           properties:
-            address: 0.0.0.0:8080
+            target: httpserver
+            values:
+              address: 0.0.0.0:8080
     - name: ponger
       type: actor
       properties:


### PR DESCRIPTION
Signed-off-by: Brooks Townsend <brooks@cosmonic.com>

## Feature or Problem
This PR removes a failing operation in a README (see https://github.com/wasmCloud/wasmCloud/issues/629) and updates the wadm manifest to properly link pinger to httpserver.

## Related Issues
https://github.com/wasmCloud/wasmCloud/issues/629

## Release Information
N/A

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
It works!
