### PR TITLE
feat: use atomic increment for kvcounter

### DIFF
--- a/actor/kvcounter-wasmcon2023/README.md
+++ b/actor/kvcounter-wasmcon2023/README.md
@@ -184,7 +184,7 @@ wash start actor file:///path/to/your/build/wasmcon2023_keyvalue_s.wasm --host <
 Your output should look something like the following:
 
 ```
-Actor [MD3T2JMVXPP2DNY3YGVIXOFHPSCOUQOE4IFOLC4EKDB3QFOTWQPHACAH] (ref: [file:///home/mrman/code/work/cosmonic/forks/examples/actor/kvcounter-wasmcon2023/build/wasmcon2023_keyvalue_s.wasm]) started on host [NAYIPQDLQE62R3XEICJZXJEOCUASMA5BC24O76H3ONVIJS7ONTNBWQYI]
+Actor [MD3T2JMVXPP2DNY3YGVIXOFHPSCOUQOE4IFOLC4EKDB3QFOTWQPHACAH] (ref: [file:///path/to/examples/actor/kvcounter-wasmcon2023/build/wasmcon2023_keyvalue_s.wasm]) started on host [NAYIPQDLQE62R3XEICJZXJEOCUASMA5BC24O76H3ONVIJS7ONTNBWQYI]
 ```
 
 Take a note of the Actor ID for your actor. For example it should look something like this:


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This adds use of `wasi:keyvalue/atomic` for doing atomic increments in the kvcounter example 

Resolves #229 

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->

Tested locally with the new Rust host (`wash` > v0.19)

The instructions show the old UI, but doing all setup with `wash` CLI works