### PR TITLE
chore: update docker-compose files

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,7 @@
 version: "4"
 services:
   nats:
-    image: nats:2.8.4-alpine
+    image: nats:2.9.22-alpine
     ports:
       - "4222:4222"
       - "6222:6222"
@@ -49,23 +49,23 @@ services:
       - "redis"
       - "grafana"
       - "tempo"
-    image: wasmcloud/wasmcloud_host:latest
+    image: wasmcloud/wasmcloud:latest
     environment:
-      RUST_LOG: debug,hyper=info
+      RUST_LOG: debug,hyper=info,async_nats=info,oci_distribution=info,cranelift_codegen=warn
+      WASMCLOUD_LOG_LEVEL: debug
       WASMCLOUD_RPC_HOST: nats
       WASMCLOUD_CTL_HOST: nats
       WASMCLOUD_PROV_RPC_HOST: nats
+      WASMCLOUD_OCI_ALLOWED_INSECURE: registry:5000
       OTEL_TRACES_EXPORTER: otlp
       OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:55681
     ports:
-      - "4000:4000"
       - "8080-8089:8080-8089" # Allows exposing examples on ports 8080-8089
 
   wadm:
     depends_on:
       - "nats"
       - "redis"
-    image: wasmcloud.azurecr.io/wadm:0.1.0
+    image: ghcr.io/wasmcloud/wadm:latest
     environment:
-      - WADM_NATS_HOST=nats
-      - WADM_REDIS_HOST=redis
+      - WADM_NATS_SERVER=nats

--- a/docker/docker-compose_without-host.yml
+++ b/docker/docker-compose_without-host.yml
@@ -7,7 +7,7 @@
 version: "3"
 services:
   nats:
-    image: nats:2.3
+    image: nats:2.9.22-alpine
     ports:
       - "4222:4222"
       - "6222:6222"
@@ -45,7 +45,6 @@ services:
     depends_on:
       - "nats"
       - "redis"
-    image: wasmcloud.azurecr.io/wadm:0.1.0
+    image: ghcr.io/wasmcloud/wadm:latest
     environment:
-      - WADM_NATS_HOST=nats
-      - WADM_REDIS_HOST=redis
+      - WADM_NATS_SERVER=nats

--- a/petclinic/docker/docker-compose.yml
+++ b/petclinic/docker/docker-compose.yml
@@ -84,17 +84,18 @@ services:
       - 55681:55681 # otlp http  
 
   wasmcloud:
-    image: wasmcloud/wasmcloud_host:0.56.0
+    image: wasmcloud/wasmcloud_host:latest
     depends_on: 
       - nats
     environment:
       LC_ALL: en_US.UTF-8
-      RUST_LOG: debug,hyper=info
-      WASMCLOUD_OCI_ALLOWED_INSECURE: registry:5000
+      RUST_LOG: debug,hyper=info,async_nats=info,oci_distribution=info,cranelift_codegen=warn
+      WASMCLOUD_LOG_LEVEL: debug
       WASMCLOUD_RPC_HOST: nats
       WASMCLOUD_CTL_HOST: nats
       WASMCLOUD_PROV_RPC_HOST: nats
       WASMCLOUD_CLUSTER_SEED: ${WASMCLOUD_CLUSTER_SEED}
+      WASMCLOUD_OCI_ALLOWED_INSECURE: registry:5000
       OTEL_TRACES_EXPORTER: otlp
       OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:55681
       HOST_app: petclinic


### PR DESCRIPTION
## Feature or Problem
This updates our docker-compose files to use more recent versions of NATS, the wasmCloud host, and wadm

## Related Issues
Resolves https://github.com/wasmCloud/examples/issues/240

## Testing

### Manual Verification
Tested manually with `docker compose up`. Confirmed each of the services ran and was able to deploy a wadm manifest successfully 